### PR TITLE
Fix BOM in lua files for 3.3.5a

### DIFF
--- a/Modules/options.lua
+++ b/Modules/options.lua
@@ -1,4 +1,4 @@
-﻿-- Author      : Potdisc
+-- Author      : Potdisc
 -- Create Date : 5/24/2012 6:24:55 PM
 -- options.lua - option frame in BlizOptions for ScroogeLoot
 

--- a/Utils/tokenData.lua
+++ b/Utils/tokenData.lua
@@ -1,4 +1,4 @@
-﻿-- Author      : Potdisc
+-- Author      : Potdisc
 -- Create Date : 3/11/2013 10:25:13 PM
 -- tokenData.lua
 -- Contains equip location and useable classes from tier tokens

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -1,4 +1,4 @@
-﻿--[[	ScroogeLoot by Potdisc
+--[[	ScroogeLoot by Potdisc
 ml_core.lua	Contains core elements for the MasterLooter
 	-	Although possible, this module shouldn't be replaced unless closely replicated as other default modules depend on it.
 	-	Assumes several functions in SessionFrame and VotingFrame


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM markers from lua files

## Testing
- `xargs -d '\n' -a /tmp/lua_files.txt -I {} sh -c 'luac5.1 -p "{}"'`


------
https://chatgpt.com/codex/tasks/task_e_6857bfc70ec08322a1538c4ac3646afa