### PR TITLE
Ensure compatibility with WotLK 3.3.5

### DIFF
--- a/compat.lua
+++ b/compat.lua
@@ -16,3 +16,31 @@ function addon:GetNumGroupMembers()
         return GetNumPartyMembers()
     end
 end
+
+function addon:UnitIsGroupLeader(unit)
+    if UnitIsGroupLeader then
+        return UnitIsGroupLeader(unit)
+    end
+    unit = unit or "player"
+    if unit == "player" then
+        if addon:IsInRaid() then
+            return IsRaidLeader()
+        elseif addon:IsInGroup() then
+            return IsPartyLeader()
+        end
+        return true
+    end
+
+    if UnitInRaid(unit) then
+        local index = GetPartyLeaderIndex()
+        return index > 0 and UnitIsUnit(unit, "raid" .. index)
+    elseif UnitInParty(unit) then
+        local index = GetPartyLeaderIndex()
+        if index == 0 then
+            return unit == "player"
+        else
+            return UnitIsUnit(unit, "party" .. index)
+        end
+    end
+    return false
+end

--- a/core.lua
+++ b/core.lua
@@ -1243,7 +1243,7 @@ function ScroogeLoot:OnEvent(event, ...)
 
 	elseif event == "RAID_INSTANCE_WELCOME" then
 		self:Debug("Event:", event, ...)
-		-- high server-side latency causes the UnitIsGroupLeader("player") condition to fail if queried quickly (upon entering instance) regardless of state.
+               -- high server-side latency causes the self:UnitIsGroupLeader("player") condition to fail if queried quickly (upon entering instance) regardless of state.
 		-- NOTE v2.0: Not sure if this is still an issue, but just add a 2 sec timer to the MLCheck call
 		self:ScheduleTimer("OnRaidEnter", 2)
 
@@ -1302,7 +1302,7 @@ end
 function ScroogeLoot:OnRaidEnter(arg)
 	-- NOTE: We shouldn't need to call GetML() as it's most likely called on "LOOT_METHOD_CHANGED"
 	-- There's no ML, and lootmethod ~= ML, but we are the group leader
-	if not self.masterLooter and UnitIsGroupLeader("player") then
+       if not self.masterLooter and self:UnitIsGroupLeader("player") then
 		-- We don't need to ask the player for usage, so change loot method to master, and make the player ML
 		if db.usage.leader then
 			SetLootMethod("master", self.playerName)


### PR DESCRIPTION
## Summary
- add WotLK backport for `UnitIsGroupLeader`
- call the compatibility wrapper in `core.lua`

## Testing
- `lua` not available so no tests run

------
https://chatgpt.com/codex/tasks/task_e_68581391c470832294bd1760483e84ee