### PR TITLE
Improve Lua 3.3.5a compatibility

### DIFF
--- a/compat.lua
+++ b/compat.lua
@@ -1,6 +1,26 @@
 -- get num group members backport
 local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
 
+-- Backfill string helpers missing in the 3.3.5a Lua API
+if not string.split then
+    ---Split a string using the WoW provided `strsplit` helper.
+    ---@param sep string
+    ---@param str string
+    ---@return ...
+    function string.split(sep, str)
+        return strsplit(sep, str)
+    end
+end
+
+if not string.trim then
+    ---Trim a string using the WoW provided `strtrim` helper.
+    ---@param str string
+    ---@return string
+    function string.trim(str)
+        return strtrim(str)
+    end
+end
+
 function addon:IsInRaid() 
     return GetNumRaidMembers() > 0
 end


### PR DESCRIPTION
## Summary
- backfill `string.split` and `string.trim` when missing
- ensure addon loads correctly on legacy clients

## Testing
- `luac -p` on all Lua files

------
https://chatgpt.com/codex/tasks/task_e_685827765dec832283f5826602d8b753