### PR TITLE
Enable ML voting visibility by default

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -124,7 +124,7 @@ function ScroogeLoot:OnInitialize()
 			selfVote = true,
 			multiVote = true,
 			anonymousVoting = false,
-			showForML = false,
+                       showForML = true,
 			hideVotes = false, -- Hide the # votes until one have voted
 			allowNotes = true,
 			autoAward = false,


### PR DESCRIPTION
## Summary
- set `showForML` to `true` so Master Looters can view voting results when anonymous voting is enabled

## Testing
- `luac -p core.lua`
- `find . -name '*.lua' -print | xargs -I {} luac -p {}` *(fails: unexpected symbol near '')*

------
https://chatgpt.com/codex/tasks/task_e_68643f5c17748322bcbaf54b765ab6b3