### PR TITLE
Implement auto-rolling on player response

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -180,14 +180,29 @@ function LootFrame:Update()
 end
 
 function LootFrame:OnRoll(entry, button)
-	addon:Debug("LootFrame:OnRoll", entry, button, "Response:", addon:GetResponseText(button))
-	local index = entries[entry].realID
-	
-	addon:SendCommand("group", "response", addon:CreateResponse(items[index].session, items[index].link, items[index].ilvl, button, items[index].equipLoc, items[index].note))
+    addon:Debug("LootFrame:OnRoll", entry, button, "Response:", addon:GetResponseText(button))
+    local index = entries[entry].realID
 
-	numRolled = numRolled + 1
-	items[index].rolled = true
-	self:Update()
+    -- Generate a random roll when the player selects a response
+    local roll = math.random(100)
+
+    addon:SendCommand(
+        "group",
+        "response",
+        addon:CreateResponse(
+            items[index].session,
+            items[index].link,
+            items[index].ilvl,
+            button,
+            items[index].equipLoc,
+            items[index].note,
+            roll
+        )
+    )
+
+    numRolled = numRolled + 1
+    items[index].rolled = true
+    self:Update()
 end
 
 function LootFrame:GetFrame()

--- a/core.lua
+++ b/core.lua
@@ -1118,8 +1118,8 @@ end
 -- @param equipLoc	The item in the session's equipLoc
 -- @param note			The player's note
 -- @returns A formatted table that can be passed directly to :SendCommand("group", "response", -return-)
-function ScroogeLoot:CreateResponse(session, link, ilvl, response, equipLoc, note)
-	self:DebugLog("CreateResponse", session, link, ilvl, response, equipLoc, note)
+function ScroogeLoot:CreateResponse(session, link, ilvl, response, equipLoc, note, roll)
+    self:DebugLog("CreateResponse", session, link, ilvl, response, equipLoc, note, roll)
 	local g1, g2 = self:GetPlayersGear(link, equipLoc)
 	local diff = nil
 	if g1 then 
@@ -1149,7 +1149,8 @@ function ScroogeLoot:CreateResponse(session, link, ilvl, response, equipLoc, not
 			ilvl = ilvl,
 			diff = diff,
 			note = note,
-			response = response
+			response = response,
+			roll = roll
 		}
 end
 


### PR DESCRIPTION
## Summary
- roll automatically when a player selects a response option
- include roll value in response data

## Testing
- `luacheck -v` *(fails: command not found)*
- `luac -p Modules/lootFrame.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644b1d277c8322ad0b1fca2493b4ba