### PR TITLE
Implement fixed loot buttons and player tracking

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -395,8 +395,12 @@ function SLVotingFrame:UpdateMoreInfo(row, data)
 		nameCheck = true
 	end
 
-	tip:AddLine(name, color.r, color.g, color.b)
-	color = {} -- Color of the response
+        tip:AddLine(name, color.r, color.g, color.b)
+        local cData = lootTable[session].candidates[name]
+        if cData.roll and cData.baseRoll then
+                tip:AddLine(string.format("Final Roll = Base Roll (%d) + SP (%d) - DP (%d) = %d", cData.baseRoll, cData.sp or 0, cData.dp or 0, cData.roll))
+        end
+        color = {} -- Color of the response
 	if nameCheck and #lootDB[name] > 0 then -- they're in the DB!
 		tip:AddLine("")
 		local nonMainspecEntries = {}
@@ -845,9 +849,17 @@ function SLVotingFrame.SetCellNote(rowFrame, frame, data, cols, row, realrow, co
 end
 
 function SLVotingFrame.SetCellRoll(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
-	local name = data[realrow].name
-	frame.text:SetText(lootTable[session].candidates[name].roll)
-	data[realrow].cols[column].value = lootTable[session].candidates[name].roll
+        local name = data[realrow].name
+        local c = lootTable[session].candidates[name]
+        frame.text:SetText(c.roll)
+        data[realrow].cols[column].value = c.roll
+        frame:SetScript("OnEnter", function()
+                local base = c.baseRoll or c.roll
+                local sp = c.sp or 0
+                local dp = c.dp or 0
+                addon:CreateTooltip(string.format("Final Roll = Base Roll (%d) + SP (%d) - DP (%d) = %d", base, sp, dp, c.roll))
+        end)
+        frame:SetScript("OnLeave", addon.HideTooltip)
 end
 
 function SLVotingFrame.filterFunc(table, row)

--- a/PlayerData.lua
+++ b/PlayerData.lua
@@ -7,29 +7,25 @@ local function updateAttendance(data)
     data.attendance = math.floor((data.attended / math.max(data.attended + data.absent, 1)) * 100)
 end
 
-function AddOrUpdatePlayer(name, class, raiderrank)
+function AddOrUpdatePlayer(name, class, isRaider)
     local p = PlayerData[name]
     if not p then
         p = {
             name = name,
             class = class,
-            raiderrank = raiderrank or false,
+            isRaider = isRaider or false,
             SP = 0,
             DP = 0,
+            tokenItems = {},
+            itemHistory = {},
             attended = 0,
             absent = 0,
             attendance = 0,
-            item1 = "",
-            item1received = false,
-            item2 = "",
-            item2received = false,
-            item3 = "",
-            item3received = false,
         }
         PlayerData[name] = p
     else
         p.class = class or p.class
-        if raiderrank ~= nil then p.raiderrank = raiderrank end
+        if isRaider ~= nil then p.isRaider = isRaider end
     end
     updateAttendance(p)
     return p

--- a/core.lua
+++ b/core.lua
@@ -652,7 +652,7 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 								if self:AutoPassCheck(v.subType, v.equipLoc, v.link) then
 									self:Debug("Autopassed on: ", v.link)
 									if not db.silentAutoPass then self:Print(format(L["Autopassed on 'item'"], v.link)) end
-									self:SendCommand("group", "response", self:CreateResponse(ses, v.link, v.ilvl, "AUTOPASS", v.equipLoc))
+                                                                        self:SendCommand("group", "response", self:CreateResponse(ses, v.link, v.ilvl, "AUTOPASS", v.equipLoc, nil, nil, nil, nil, nil))
 									lootTable[ses].autopass = true
 								end
 							else
@@ -1118,8 +1118,8 @@ end
 -- @param equipLoc	The item in the session's equipLoc
 -- @param note			The player's note
 -- @returns A formatted table that can be passed directly to :SendCommand("group", "response", -return-)
-function ScroogeLoot:CreateResponse(session, link, ilvl, response, equipLoc, note, roll)
-    self:DebugLog("CreateResponse", session, link, ilvl, response, equipLoc, note, roll)
+function ScroogeLoot:CreateResponse(session, link, ilvl, response, equipLoc, note, roll, sp, dp, baseRoll)
+    self:DebugLog("CreateResponse", session, link, ilvl, response, equipLoc, note, roll, sp, dp, baseRoll)
 	local g1, g2 = self:GetPlayersGear(link, equipLoc)
 	local diff = nil
 	if g1 then 
@@ -1150,8 +1150,11 @@ function ScroogeLoot:CreateResponse(session, link, ilvl, response, equipLoc, not
 			diff = diff,
 			note = note,
 			response = response,
-			roll = roll
-		}
+			roll = roll,
+                        sp = sp,
+                        dp = dp,
+                        baseRoll = baseRoll
+                }
 end
 
 function ScroogeLoot:GetPlayersGuildRank()
@@ -1270,6 +1273,11 @@ function ScroogeLoot:OnEvent(event, ...)
                        self:GetGuildOptions() -- get the guild data to the options table now that it's ready
                end
        end
+end
+
+function ScroogeLoot:CanUseItem(playerName, itemLink)
+       -- Simple placeholder; assumes local player can always use the item
+       return true
 end
 
 function ScroogeLoot:OnGroupRosterUpdate()

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -678,6 +678,19 @@ function ScroogeLootML:TrackAndLogLoot(name, item, response, boss, votes, itemRe
 	history_table["class"]			= self.candidates[name].class											-- New in v2.0
 	history_table["isAwardReason"] = reason and true or false											-- New in v2.0
 
+        if PlayerData and PlayerData[name] then
+                local itemName = GetItemInfo(item)
+                if itemName then
+                        PlayerData[name].itemHistory = PlayerData[name].itemHistory or {}
+                        PlayerData[name].itemHistory[itemName] = true
+                end
+                if response == 1 then
+                        PlayerData[name].SP = 0
+                elseif response == 3 then
+                        PlayerData[name].DP = (PlayerData[name].DP or 0) - 50
+                end
+        end
+
 	if db.sendHistory then -- Send it, and let comms handle the logging
 		addon:SendCommand("group", "history", name, history_table)
 	elseif db.enableHistory then -- Just log it


### PR DESCRIPTION
## Summary
- add permanent roll buttons and button state logic
- update PlayerData with raider, SP, DP, tokens and history
- adjust roll handling to apply SP/DP modifiers and auto-vote
- display roll breakdown tooltip on VotingFrame
- track awards and modify PlayerData accordingly

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f1abc09883228750a9d5de71cdf9