### PR TITLE
Restrict PlayerData edits to ML

### DIFF
--- a/PlayerData.lua
+++ b/PlayerData.lua
@@ -3,6 +3,12 @@
 
 PlayerData = PlayerData or {}
 
+local addon = LibStub("AceAddon-3.0"):GetAddon("RCLootCouncil")
+
+function CanEditPlayerData()
+    return addon.isMasterLooter
+end
+
 function AddOrUpdatePlayer(name, class, raiderrank)
     local p = PlayerData[name]
     if not p then
@@ -46,6 +52,7 @@ function IsPlayerInRaid(name)
 end
 
 function RaidDayReward()
+    if not CanEditPlayerData() then return end
     for name, data in pairs(PlayerData) do
         if IsPlayerInRaid(name) then
             data.SP = (data.SP or 0) + 5
@@ -55,14 +62,13 @@ function RaidDayReward()
         end
         updateAttendance(data)
     end
+    BroadcastPlayerData()
 end
 
 function BroadcastPlayerData()
-    if UnitIsGroupLeader("player") or IsMasterLooter() then
-        if AceSerializer then
-            local serialized = AceSerializer:Serialize(PlayerData)
-            SendAddonMessage("PlayerDataUpdate", serialized, "RAID")
-        end
+    if CanEditPlayerData() and AceSerializer then
+        local serialized = AceSerializer:Serialize(PlayerData)
+        SendAddonMessage("PlayerDataUpdate", serialized, "RAID")
     end
 end
 

--- a/core.lua
+++ b/core.lua
@@ -1264,6 +1264,7 @@ function RCLootCouncil:OnEvent(event, ...)
 end
 
 function RCLootCouncil:OnGroupRosterUpdate()
+       if not CanEditPlayerData() then return end
        local num = GetNumGroupMembers() or 0
        for i = 1, num do
                local name, _, _, _, class = GetRaidRosterInfo(i)
@@ -1271,6 +1272,7 @@ function RCLootCouncil:OnGroupRosterUpdate()
                        AddOrUpdatePlayer(name, class)
                end
        end
+       BroadcastPlayerData()
 end
 
 function RCLootCouncil:NewMLCheck()


### PR DESCRIPTION
## Summary
- add a `CanEditPlayerData()` helper in `PlayerData.lua`
- only the master looter can modify or broadcast `PlayerData`
- update roster changes to respect the master looter guard

## Testing
- `lua` was not available so no linting or syntax tests were run

------
https://chatgpt.com/codex/tasks/task_e_68651b36738083229fe18f29d6d30714