### PR TITLE
Add PlayerData management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ScroogeLoot
 addon for loot management for Epoch WoW
+
+## Player Data
+
+The addon maintains a `PlayerData` table containing raid member information.
+Only the master looter is allowed to modify the table. Attendance percentage is
+derived from `attended / (attended + absent)`.

--- a/ScroogeLoot.toc
+++ b/ScroogeLoot.toc
@@ -12,6 +12,7 @@ Locale\Locales.xml
 core.lua
 ml_core.lua
 compat.lua
+playerdata.lua
 Modules\Modules.xml
 
 Utils\tokenData.lua

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -1,0 +1,53 @@
+-- PlayerData holds raid member information such as class and attendance.
+-- Only the master looter may modify the table.
+
+local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
+
+addon.PlayerData = addon.PlayerData or {}
+
+-- Creates entry for player if not present
+local function EnsurePlayer(name)
+    if not addon.PlayerData[name] then
+        addon.PlayerData[name] = {
+            class = "",
+            raiderrank = false,
+            SP = 0,
+            DP = 0,
+            attended = 0,
+            absent = 0,
+            attendance = 100,
+            item1 = nil, item1received = false,
+            item2 = nil, item2received = false,
+            item3 = nil, item3received = false,
+        }
+    end
+end
+
+-- Update an arbitrary field on a player. Only works for the master looter.
+function addon:SetPlayerField(name, field, value)
+    if not self.isMasterLooter then return end
+    EnsurePlayer(name)
+    self.PlayerData[name][field] = value
+end
+
+-- Increment attendance values and update derived attendance field.
+function addon:ModifyAttendance(name, attendedInc, absentInc)
+    if not self.isMasterLooter then return end
+    EnsurePlayer(name)
+    local data = self.PlayerData[name]
+    data.attended = (data.attended or 0) + (attendedInc or 0)
+    data.absent = (data.absent or 0) + (absentInc or 0)
+    local total = data.attended + data.absent
+    if total > 0 then
+        data.attendance = math.floor((data.attended / total) * 100)
+    else
+        data.attendance = 100
+    end
+end
+
+-- Retrieve a player's data table (read only)
+function addon:GetPlayerData(name)
+    EnsurePlayer(name)
+    return self.PlayerData[name]
+end
+


### PR DESCRIPTION
## Summary
- document how PlayerData works
- load new `playerdata.lua`
- implement PlayerData helpers guarded by master looter check

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a43f9e83083229215eb302ac251c0