### PR TITLE
Implement PlayerData sync feature

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -344,3 +344,5 @@ L["You cannot use this command without being the Master Looter"] = true
 L["You haven't set a council! You can edit your council by typing '/rc council'"] = true
 L["You're already running a session."] = true
 L["Your note:"] = true
+L["Player Management"] = true
+L["Open Player Manager"] = true

--- a/Modules/options.lua
+++ b/Modules/options.lua
@@ -851,10 +851,23 @@ function addon:OptionsTable()
 							},
 						},
 					},
-				},
-			},
-		},
-	}
+                                },
+                        },
+                },
+        }
+
+        options.args.mlSettings.args.PlayerDataManagement = {
+                name = L["Player Management"],
+                type = "group",
+                order = 10,
+                args = {
+                        open = {
+                                type = "execute",
+                                name = L["Open Player Manager"],
+                                func = function() SLPlayerManager:Show() end
+                        }
+                }
+        }
 
 	-- #region Create options thats made with loops
 	-- Buttons

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ addon for loot management for Epoch WoW
 The addon maintains a `PlayerData` table containing raid member information.
 Only the master looter is allowed to modify the table. Attendance percentage is
 derived from `attended / (attended + absent)`.
+
+### Syncing PlayerData
+
+The master looter's copy is the source of truth. Whenever the master updates
+`PlayerData`, the new table is broadcast to the group using AceComm so that all
+clients stay in sync.

--- a/core.lua
+++ b/core.lua
@@ -718,6 +718,12 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 			elseif command == "playerInfoRequest" then
 				self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
 
+			elseif command == "playerData" then
+				-- Update local PlayerData from the master looter
+				if not self.isMasterLooter then
+					local incomingData = unpack(data)
+					self.PlayerData = incomingData
+				end
 			elseif command == "message" then
 				self:Print(unpack(data))
 

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -28,6 +28,7 @@ function addon:SetPlayerField(name, field, value)
     if not self.isMasterLooter then return end
     EnsurePlayer(name)
     self.PlayerData[name][field] = value
+    self:BroadcastPlayerData()
 end
 
 -- Increment attendance values and update derived attendance field.
@@ -43,11 +44,19 @@ function addon:ModifyAttendance(name, attendedInc, absentInc)
     else
         data.attendance = 100
     end
+    self:BroadcastPlayerData()
 end
 
 -- Retrieve a player's data table (read only)
 function addon:GetPlayerData(name)
     EnsurePlayer(name)
     return self.PlayerData[name]
+end
+
+-- Broadcast the complete PlayerData table to the raid.
+function addon:BroadcastPlayerData()
+    if not self.isMasterLooter then return end
+    -- Send to everyone in the current group/raid
+    self:SendCommand("group", "playerData", self.PlayerData)
 end
 


### PR DESCRIPTION
## Summary
- sync PlayerData across the raid
- document sync behaviour in README

## Testing
- `git commit -m "Implement PlayerData sync"`

------
https://chatgpt.com/codex/tasks/task_e_686a44f1a2c88322afaaffc4ebcf0cba