### PR TITLE
Add Player Management tab

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -344,3 +344,5 @@ L["You cannot use this command without being the Master Looter"] = true
 L["You haven't set a council! You can edit your council by typing '/rc council'"] = true
 L["You're already running a session."] = true
 L["Your note:"] = true
+L["Player Management"] = true
+L["Open Player Manager"] = true

--- a/Modules/options.lua
+++ b/Modules/options.lua
@@ -851,10 +851,23 @@ function addon:OptionsTable()
 							},
 						},
 					},
-				},
-			},
-		},
-	}
+                                },
+                        },
+                },
+        }
+
+        options.args.mlSettings.args.PlayerDataManagement = {
+                name = L["Player Management"],
+                type = "group",
+                order = 10,
+                args = {
+                        open = {
+                                type = "execute",
+                                name = L["Open Player Manager"],
+                                func = function() SLPlayerManager:Show() end
+                        }
+                }
+        }
 
 	-- #region Create options thats made with loops
 	-- Buttons


### PR DESCRIPTION
## Summary
- add PlayerDataManagement tab entry in options
- add Player Management phrases to enUS locale

## Testing
- `luac -p Modules/options.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a46d519bc8322b1334a655b501810