### PR TITLE
Rename slash commands from /rc to /sl

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -10,7 +10,7 @@ debug = false
 local L = LibStub("AceLocale-3.0"):NewLocale("ScroogeLoot", "enUS", true, debug)
 if not L then return end
 
-L["A new session has begun, type '/rc open' to open the voting frame."] = true
+L["A new session has begun, type '/sl open' to open the voting frame."] = true
 L["Append realm names"] = true
 L[" is not active in this raid."] = true
 L["Now handles looting"] = true
@@ -63,7 +63,7 @@ L["auto_award_desc"] = "Activates Auto Award."
 L["auto_award_to_desc"] = "The player to Auto Award items to. A selectable list of raid members appear if you're in a raid group."
 L["auto_enable_desc"] = "Check to always let ScroogeLoot handle loot. Unchecking will make the addon ask if you want to use it every time you enter a raid or become Master Looter."
 L["auto_loot_desc"] = "Enables autolooting of all equippable items"
-L["auto_open_desc"] = "Check to Auto Open the voting frame when available. The voting frame can otherwise be opened with /rc open. Note: This requires permission from the Master Looter."
+L["auto_open_desc"] = "Check to Auto Open the voting frame when available. The voting frame can otherwise be opened with /sl open. Note: This requires permission from the Master Looter."
 L["auto_pass_boe_desc"] = "Uncheck to never autopass Bind on Equip items."
 L["auto_pass_desc"] = "Check to enable autopassing of items your class cannot use."
 L["auto_start_desc"] = "Enables Auto Start, i.e. start a session with all eligible items. Disabling will show a editable item list before starting a session."
@@ -344,6 +344,6 @@ L["You can't start a session before all items are loaded!"] = true
 L["You cannot initiate a test while in a group without being the MasterLooter."] = true
 L["You cannot use the menu when the session has ended."] = true
 L["You cannot use this command without being the Master Looter"] = true
-L["You haven't set a council! You can edit your council by typing '/rc council'"] = true
+L["You haven't set a council! You can edit your council by typing '/sl council'"] = true
 L["You're already running a session."] = true
 L["Your note:"] = true

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -186,7 +186,7 @@ function SLVotingFrame:OnCommReceived(prefix, serializedMsg, distri, sender)
 				if db.autoOpen then
 					self:Show()
 				else
-					addon:Print(L['A new session has begun, type "/rc open" to open the voting frame.'])
+                                       addon:Print(L['A new session has begun, type "/sl open" to open the voting frame.'])
 				end
 				guildRanks = addon:GetGuildRanks() -- Just update it on every session
 

--- a/core.lua
+++ b/core.lua
@@ -219,8 +219,8 @@ function ScroogeLoot:OnInitialize()
 	end
 
 	-- register chat and comms
-	self:RegisterChatCommand("rc", "ChatCommand")
-  	self:RegisterChatCommand("rclc", "ChatCommand")
+       self:RegisterChatCommand("sl", "ChatCommand")
+       self:RegisterChatCommand("rclc", "ChatCommand")
 	self:RegisterComm("ScroogeLoot")
 	self:RegisterComm("ScroogeLoot_WotLK")
 	self.db = LibStub("AceDB-3.0"):New("ScroogeLootDB", self.defaults, true)
@@ -337,7 +337,7 @@ function ScroogeLoot:OnEnable()
 					self.isMasterLooter = true
 					self.masterLooter = self.playerName
 					if #db.council == 0 then -- if there's no council
-						self:Print(L["You haven't set a council! You can edit your council by typing '/rc council'"])
+                                               self:Print(L["You haven't set a council! You can edit your council by typing '/sl council'"])
 					end
 					self:CallModule("masterlooter")
 					self:GetActiveModule("masterlooter"):NewML(self.masterLooter)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -58,7 +58,7 @@ function ScroogeLootML:AddItem(item, bagged, slotIndex, index)
 	addon:DebugLog("ML:AddItem", item, bagged, slotIndex, index)
 	local name, link, rarity, ilvl, iMinLevel, type, subType, iStackCount, equipLoc, texture = GetItemInfo(item)
 	
-	-- Item isn't properly loaded, so update the data in 0.5 sec (Should only happen with /rc test)
+       -- Item isn't properly loaded, so update the data in 0.5 sec (Should only happen with /sl test)
 	if not name then
 		self:ScheduleTimer("Timer", 0.5, "AddItem", item, bagged, slotIndex, #self.lootTable)
 		GameTooltip:SetHyperlink("item:"..item) -- cace item asap


### PR DESCRIPTION
## Summary
- rename the primary chat command from `/rc` to `/sl`
- update help text and council warnings to reference `/sl`
- adjust voting frame start message and code comments accordingly

## Testing
- `lua` interpreter missing: `lua -e 'assert(loadfile("core.lua"))'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8b6495ac8322b7ffd261b47214af