### PR TITLE
Implement 6-button roll system

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -10,11 +10,65 @@ local LibDialog = LibStub("LibDialog-1.0")
 local L = LibStub("AceLocale-3.0"):GetLocale("ScroogeLoot")
 local LibToken = LibStub("LibArmorToken-1.0")
 
+ROLL_BUTTONS = {
+  { id = 1, name = "Scrooge", logic = "scrooge" },
+  { id = 2, name = "Drool", logic = "drool" },
+  { id = 3, name = "Deducktion", logic = "deducktion" },
+  { id = 4, name = "Main-Spec", logic = "main" },
+  { id = 5, name = "Off-Spec", logic = "off" },
+  { id = 6, name = "Transmog", logic = "transmog" },
+}
+
+
 local items = {} -- item.i = {name, link, lvl, texture} (i == session)
 local entries = {}
 local ENTRY_HEIGHT = 75
 local MAX_ENTRIES = 5
 local numRolled = 0
+
+-- Simple placeholder helper checks
+local function PlayerHasItemToken(p, item) return true end
+local function PlayerGotItem(p, item) return false end
+local function CanEquipItem(name, item) return true end
+
+-- Handles rolling logic for the custom buttons
+function HandleRollClick(playerName, rollType, sessionID, item)
+  local p = addon.PlayerData and addon.PlayerData[playerName]
+  if not p then return end
+
+  local baseRoll = math.random(100)
+  local finalRoll = baseRoll
+  local reason = ""
+
+  if rollType == 1 then
+    finalRoll = baseRoll + (p.SP or 0)
+    reason = "+SP"
+  elseif rollType == 2 then
+    finalRoll = baseRoll
+    reason = "No SP/DP"
+  elseif rollType == 3 or rollType == 4 or rollType == 5 then
+    finalRoll = baseRoll - (p.DP or 0)
+    reason = "-DP"
+  elseif rollType == 6 then
+    finalRoll = baseRoll
+    reason = "Transmog Roll"
+    SendChatMessage("Thank you for making a small totally optional donation to the guild bank ;)", "WHISPER", nil, playerName)
+  end
+
+  local vf = addon:GetModule("SLVotingFrame")
+  vf:SetCandidateData(sessionID, playerName, "roll", finalRoll)
+  vf:SetCandidateData(sessionID, playerName, "rollInfo", {
+    base = baseRoll,
+    final = finalRoll,
+    reason = reason,
+    SP = p.SP,
+    DP = p.DP,
+  })
+  if vf.frame and vf.frame.st then
+    vf.frame.st:Refresh()
+  end
+  vf:Update()
+end
 
 function LootFrame:Start(table)
 	addon:DebugLog("LootFrame:Start()")
@@ -180,14 +234,14 @@ function LootFrame:Update()
 end
 
 function LootFrame:OnRoll(entry, button)
-	addon:Debug("LootFrame:OnRoll", entry, button, "Response:", addon:GetResponseText(button))
-	local index = entries[entry].realID
-	
-	addon:SendCommand("group", "response", addon:CreateResponse(items[index].session, items[index].link, items[index].ilvl, button, items[index].equipLoc, items[index].note))
+       addon:Debug("LootFrame:OnRoll", entry, button, "Response:", addon:GetResponseText(button))
+       local index = entries[entry].realID
 
-	numRolled = numRolled + 1
-	items[index].rolled = true
-	self:Update()
+       HandleRollClick(UnitName("player"), button, items[index].session, items[index].link)
+
+       numRolled = numRolled + 1
+       items[index].rolled = true
+       self:Update()
 end
 
 function LootFrame:GetFrame()

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -874,9 +874,18 @@ function SLVotingFrame.SetCellNote(rowFrame, frame, data, cols, row, realrow, co
 end
 
 function SLVotingFrame.SetCellRoll(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
-	local name = data[realrow].name
-	frame.text:SetText(lootTable[session].candidates[name].roll)
-	data[realrow].cols[column].value = lootTable[session].candidates[name].roll
+       local name = data[realrow].name
+       local info = lootTable[session].candidates[name].rollInfo or {}
+       frame.text:SetText(lootTable[session].candidates[name].roll)
+       frame:SetScript("OnEnter", function()
+               addon:CreateTooltip(
+                       "Base: "..tostring(info.base),
+                       info.reason == "+SP" and "+SP: "..tostring(info.SP) or info.reason == "-DP" and "-DP: "..tostring(info.DP) or nil,
+                       "Final: "..tostring(info.final)
+               )
+       end)
+       frame:SetScript("OnLeave", addon.HideTooltip)
+       data[realrow].cols[column].value = lootTable[session].candidates[name].roll
 end
 
 function SLVotingFrame.filterFunc(table, row)

--- a/core.lua
+++ b/core.lua
@@ -82,9 +82,12 @@ function ScroogeLoot:OnInitialize()
 		PASS				= { color = {0.7, 0.7,0.7,1},		sort = 800,		text = L["Pass"],},
 		AUTOPASS			= { color = {0.7,0.7,0.7,1},		sort = 801,		text = L["Autopass"], },
 		DISABLED			= { color = {0.3, 0.35, 0.5},		sort = 802,		text = L["Candidate has disabled ScroogeLoot"], },
-		--[[1]]			  { color = {0,1,0,1},				sort = 1,		text = L["Mainspec/Need"],},
-		--[[2]]			  { color = {1,0.5,0,1},			sort = 2,		text = L["Offspec/Greed"],	},
-		--[[3]]			  { color = {0,0.7,0.7,1},			sort = 3,		text = L["Minor Upgrade"],},
+		--[[1]]			  { color = {0,1,0,1},				sort = 1,		text = "Scrooge",},
+		--[[2]]			  { color = {1,0.5,0,1},			sort = 2,		text = "Drool",	},
+		--[[3]]			  { color = {0,0.7,0.7,1},			sort = 3,		text = "Deducktion",},
+                --[[4]]                   { color = {1,1,0,1},               sort = 4,                text = "Main-Spec",},
+                --[[5]]                   { color = {0.9,0.6,1,1},             sort = 5,                text = "Off-Spec",},
+                --[[6]]                   { color = {0.7,0.7,0.7,1},           sort = 6,                text = "Transmog",},
 	}
 	self.roleTable = {
 		TANK =		L["Tank"],
@@ -171,12 +174,16 @@ function ScroogeLoot:OnInitialize()
 			council = {},
 
 			maxButtons = 10,
-			numButtons = 3,
+			numButtons = 6,
 			buttons = {
-				{	text = L["Need"],					whisperKey = L["whisperKey_need"], },	-- 1
-				{	text = L["Greed"],				whisperKey = L["whisperKey_greed"],},	-- 2
-				{	text = L["Minor Upgrade"],		whisperKey = L["whisperKey_minor"],},	-- 3
-			},
+				{       text = "Scrooge", whisperKey = "scrooge" },
+                                {       text = "Drool", whisperKey = "drool" },
+                                {       text = "Deducktion", whisperKey = "deducktion" },
+                                {       text = "Main-Spec", whisperKey = "main" },
+                                {       text = "Off-Spec", whisperKey = "off" },
+                                {       text = "Transmog", whisperKey = "transmog" },
+
+                        },
 			maxAwardReasons = 10,
 			numAwardReasons = 3,
 			awardReasons = {


### PR DESCRIPTION
## Summary
- add 6 default roll buttons and new responses
- implement roll logic handling SP/DP adjustments
- display roll breakdown in VotingFrame tooltips

## Testing
- `luac -p core.lua`
- `luac -p Modules/lootFrame.lua`
- `luac -p Modules/votingFrame.lua`

------
https://chatgpt.com/codex/tasks/task_e_686a8c81cfac8322b76603b72453eb00