### PR TITLE
Add debug prints for voting session start

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -179,16 +179,17 @@ function SLVotingFrame:OnCommReceived(prefix, serializedMsg, distri, sender)
 				end
 				self:Update()
 
-			elseif command == "lootTable" and addon:UnitIsUnit(sender, addon.masterLooter) then
-				active = true
-				self:Setup(unpack(data))
-				if not addon.enabled then return end -- We just want things ready
-				if db.autoOpen then
-					self:Show()
-				else
+                        elseif command == "lootTable" and addon:UnitIsUnit(sender, addon.masterLooter) then
+                                print("Voting frame received lootTable session")
+                                active = true
+                                self:Setup(unpack(data))
+                                if not addon.enabled then return end -- We just want things ready
+                                if db.autoOpen then
+                                        self:Show()
+                                else
                                        addon:Print(L['A new session has begun, type "/sl open" to open the voting frame.'])
-				end
-				guildRanks = addon:GetGuildRanks() -- Just update it on every session
+                                end
+                                guildRanks = addon:GetGuildRanks() -- Just update it on every session
 
 			elseif command == "response" then
 				local session, name, t = unpack(data)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -195,7 +195,8 @@ function ScroogeLootML:StartSession()
 	end
 
 	self.running = true
-	addon:SendCommand("group", "lootTable", self.lootTable)
+        addon:SendCommand("group", "lootTable", self.lootTable)
+        addon:Debug("Sent lootTable", #self.lootTable)
 
 	self:AnnounceItems()
 	-- Start a timer to set response as offline/not installed unless we receive an ack


### PR DESCRIPTION
## Summary
- log when sending loot table to the group
- log when the voting frame receives the loot table

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9364b5588322bbbb3c06e69817e0