### PR TITLE
Implement VotingFrame message handlers

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -51,21 +51,25 @@ function SLVotingFrame:OnInitialize()
 end
 
 function SLVotingFrame:OnEnable()
-	self:RegisterComm("ScroogeLoot")
-	db = addon:Getdb()
-	active = true
-	moreInfo = db.modules["SLVotingFrame"].moreInfo
-	self.frame = self:GetFrame()
+        self:RegisterComm("ScroogeLoot")
+        addon:RegisterMessage("SL_LOOT_TABLE", "HandleLootTable")
+        addon:RegisterMessage("SL_PLAYER_DATA", "HandlePlayerData")
+        db = addon:Getdb()
+        active = true
+        moreInfo = db.modules["SLVotingFrame"].moreInfo
+        self.frame = self:GetFrame()
 end
 
 function SLVotingFrame:OnDisable() -- We never really call this
-	self:Hide()
-	self.frame:SetParent(nil)
-	self.frame = nil
-	wipe(lootTable)
-	active = false
-	session = 1
-	self:UnregisterAllComm()
+        self:Hide()
+        self.frame:SetParent(nil)
+        self.frame = nil
+        wipe(lootTable)
+        active = false
+        session = 1
+        addon:UnregisterMessage("SL_LOOT_TABLE")
+        addon:UnregisterMessage("SL_PLAYER_DATA")
+        self:UnregisterAllComm()
 end
 
 function SLVotingFrame:Hide()
@@ -196,9 +200,28 @@ function SLVotingFrame:OnCommReceived(prefix, serializedMsg, distri, sender)
 					self:SetCandidateData(session, name, k, v)
 				end
 				self:Update()
-			end
-		end
-	end
+                        end
+                end
+        end
+end
+
+function SLVotingFrame:HandleLootTable(event, table)
+        active = true
+        self:Setup(table)
+        if not addon.enabled then return end
+        if db.autoOpen then
+                self:Show()
+        else
+                addon:Print(L['A new session has begun, type "/sl open" to open the voting frame.'])
+        end
+        guildRanks = addon:GetGuildRanks()
+end
+
+function SLVotingFrame:HandlePlayerData(event, data)
+        addon.PlayerData = data
+        if self.frame and self.frame:IsShown() then
+                self:Update()
+        end
 end
 
 -- Getter/Setter for candidate data

--- a/core.lua
+++ b/core.lua
@@ -662,9 +662,12 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 
 					-- Show  the LootFrame
 					self:CallModule("lootframe")
-					self:GetActiveModule("lootframe"):Start(lootTable)
+                                        self:GetActiveModule("lootframe"):Start(lootTable)
 
-					-- The votingFrame handles lootTable itself
+                                        -- Notify other modules about the new loot table
+                                        self:SendMessage("SL_LOOT_TABLE", lootTable)
+
+                                        -- The votingFrame handles lootTable itself
 
 				else -- a non-ML send a lootTable?!
 					self:Debug(tostring(sender).." is not ML, but sent lootTable!")
@@ -725,12 +728,14 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 			elseif command == "playerInfoRequest" then
 				self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
 
-			elseif command == "playerData" then
-				-- Update local PlayerData from the master looter
-				if not self.isMasterLooter then
-					local incomingData = unpack(data)
-					self.PlayerData = incomingData
-				end
+                        elseif command == "playerData" then
+                                -- Update local PlayerData from the master looter
+                                if not self.isMasterLooter then
+                                        local incomingData = unpack(data)
+                                        self.PlayerData = incomingData
+                                        -- Forward the data to interested modules
+                                        self:SendMessage("SL_PLAYER_DATA", incomingData)
+                                end
 			elseif command == "message" then
 				self:Print(unpack(data))
 


### PR DESCRIPTION
## Summary
- add internal event notifications when receiving loot tables and player data
- show VotingFrame automatically by listening for these events

## Testing
- `luac` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_686a97ad67308322a645532a4f957dd3