### PR TITLE
Allow editing player names in manager

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -110,6 +110,7 @@ L["chat_commands"] = [=[
 - add [item]- Add an item to the session frame
 - award     - Start a session with items looted to your inventory
 - winners   - Display the winners of awarded items looted to your inventory
+- pm        - Open the Player Management window
 ]=]
 L["Check this to loot the items and distribute them later."] = true
 L["Check to append the realmname of a player from another realm"] = true

--- a/Modules/playerManager.lua
+++ b/Modules/playerManager.lua
@@ -8,7 +8,7 @@ local ROW_HEIGHT = 20
 
 function SLPlayerManager:OnInitialize()
     self.scrollCols = {
-        {name=L["Name"], width=100, DoCellUpdate=function(...) SLPlayerManager:SetCellName(...) end},
+        {name=L["Name"], width=100, DoCellUpdate=function(row,frame,data,cols,rowI,realrow,col,fShow,table,...) SLPlayerManager:SetCellEdit(row,frame,data,cols,rowI,realrow,col,fShow,table,"name") end},
         {name=L["Class"], width=70, DoCellUpdate=function(row,frame,data,cols,rowI,realrow,col,fShow,table,...) SLPlayerManager:SetCellEdit(row,frame,data,cols,rowI,realrow,col,fShow,table,"class") end},
         {name=L["Raider"], width=60, DoCellUpdate=function(row,frame,data,cols,rowI,realrow,col,fShow,table,...) SLPlayerManager:SetCellCheck(row,frame,data,cols,rowI,realrow,col,fShow,table,"raiderrank") end},
         {name="SP", width=40, DoCellUpdate=function(row,frame,data,cols,rowI,realrow,col,fShow,table,...) SLPlayerManager:SetCellEdit(row,frame,data,cols,rowI,realrow,col,fShow,table,"SP") end},
@@ -94,9 +94,10 @@ function SLPlayerManager:LoadData()
     for name,data in pairs(addon.PlayerData) do
         local copy = {}
         for k,v in pairs(data) do copy[k] = v end
+        copy.name = name
         local row = {name=name, data=copy}
         row.cols = {
-            {value=name},
+            {value=copy.name},
             {value=copy.class},
             {value=copy.raiderrank},
             {value=copy.SP},
@@ -112,10 +113,6 @@ function SLPlayerManager:LoadData()
         }
         tinsert(self.frame.rows, row)
     end
-end
-
-function SLPlayerManager:SetCellName(rowFrame, frame, data, cols, row, realrow, column, fShow, table)
-    frame.text:SetText(data[realrow].name)
 end
 
 function SLPlayerManager:SetCellEdit(rowFrame, frame, data, cols, row, realrow, column, fShow, table, field)
@@ -173,7 +170,9 @@ function SLPlayerManager:Save()
         else
             pd.attendance = 100
         end
-        addon.PlayerData[row.name] = pd
+        local name = d.name or row.name
+        addon.PlayerData[name] = pd
+        row.name = name
     end
     addon:BroadcastPlayerData()
     addon:Print(L["Player Management"]..": "..L["Save"].."!")
@@ -207,6 +206,7 @@ function SLPlayerManager:ImportData(text)
         local name = entry:match('name="([^"]*)"')
         if name then
             local d = {}
+            d.name = name
             d.class = entry:match('class="([^"]*)"') or ""
             d.raiderrank = entry:match('raider="([^"]*)"') == "true"
             d.SP = tonumber(entry:match('SP="([^"]*)"') or 0)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ derived from `attended / (attended + absent)`.
 The master looter's copy is the source of truth. Whenever the master updates
 `PlayerData`, the new table is broadcast to the group using AceComm so that all
 clients stay in sync.
+
+### Editing PlayerData
+
+Use `/sl pm` in game to open the **Player Management** window. All fields of the
+`PlayerData` table can be edited directly in this window. Saving will broadcast
+the updated table to the raid.

--- a/core.lua
+++ b/core.lua
@@ -478,8 +478,12 @@ function ScroogeLoot:ChatCommand(msg)
 	elseif input == 'version' or input == L["version"] or input == "v" or input == "ver" then
 		self:CallModule("version")
 
-	elseif input == "history" or input == L["history"] or input == "h" or input == "his" then
-		self:CallModule("history")
+        elseif input == "history" or input == L["history"] or input == "h" or input == "his" then
+                self:CallModule("history")
+
+        elseif input == "pm" or input == "playermanager" then
+                local pm = self:GetModule("SLPlayerManager", true)
+                if pm then pm:Show() end
 --@debug@
 	elseif input == "nnp" then
 		self.nnp = not self.nnp


### PR DESCRIPTION
## Summary
- enable editing of the player name column in the Player Manager
- expose player manager via `/sl pm`
- document new command
- update help text for the command

## Testing
- `luajit` was not available so syntax checks could not be executed

------
https://chatgpt.com/codex/tasks/task_e_686fea116b6c83228b9c5b1964830c23