### PR TITLE
Add editable player table directly in options

### DIFF
--- a/Libs/AceGUI-3.0/AceGUI-3.0.xml
+++ b/Libs/AceGUI-3.0/AceGUI-3.0.xml
@@ -23,6 +23,7 @@
 	<Script file="widgets\AceGUIWidget-InteractiveLabel.lua"/>
 	<Script file="widgets\AceGUIWidget-Keybinding.lua"/>
 	<Script file="widgets\AceGUIWidget-Label.lua"/>
-	<Script file="widgets\AceGUIWidget-MultiLineEditBox.lua"/>
-	<Script file="widgets\AceGUIWidget-Slider.lua"/>
+        <Script file="widgets\AceGUIWidget-MultiLineEditBox.lua"/>
+        <Script file="widgets\AceGUIWidget-Slider.lua"/>
+        <Script file="widgets\AceGUIWidget-SLPlayerManager.lua"/>
 </Ui>

--- a/Libs/AceGUI-3.0/widgets/AceGUIWidget-SLPlayerManager.lua
+++ b/Libs/AceGUI-3.0/widgets/AceGUIWidget-SLPlayerManager.lua
@@ -1,0 +1,38 @@
+local Type, Version = "SLPlayerManager", 1
+local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
+if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
+
+-- WoW API
+local CreateFrame = CreateFrame
+
+local addon = ScroogeLoot
+local SLPlayerManager = addon and addon:GetModule("SLPlayerManager", true)
+
+local methods = {
+    ["OnAcquire"] = function(self)
+        self:SetWidth(900)
+        self:SetHeight(400)
+        if SLPlayerManager and not self.created then
+            SLPlayerManager:CreateOptionsUI(self.frame)
+            self.created = true
+        end
+        if SLPlayerManager then
+            SLPlayerManager:LoadData(self.frame)
+        end
+    end,
+}
+
+local function Constructor()
+    local frame = CreateFrame("Frame", nil, UIParent)
+    frame:Hide()
+    local widget = {
+        frame = frame,
+        type = Type,
+    }
+    for method, func in pairs(methods) do
+        widget[method] = func
+    end
+    return AceGUI:RegisterAsWidget(widget)
+end
+
+AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/Modules/options.lua
+++ b/Modules/options.lua
@@ -856,10 +856,11 @@ function addon:OptionsTable()
                                                 type = "group",
                                                 order = 10,
                                                 args = {
-                                                        open = {
-                                                                type = "execute",
-                                                                name = L["Open Player Manager"],
-                                                                func = function() SLPlayerManager:Show() end
+                                                        table = {
+                                                                type = "description",
+                                                                name = "",
+                                                                width = "full",
+                                                                dialogControl = "SLPlayerManager",
                                                         }
                                                 }
                                         },


### PR DESCRIPTION
## Summary
- add custom AceGUI widget to embed player manager table
- load player management UI inside options tab using the new widget
- refactor player manager module to share UI creation for window and options

## Testing
- `luac`/`lua` not available, so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_686ff4c1106c832296219186944ccf65