### PR TITLE
Persist player data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ addon for loot management for Epoch WoW
 
 The addon maintains a `PlayerData` table containing raid member information.
 Only the master looter is allowed to modify the table. Attendance percentage is
-derived from `attended / (attended + absent)`.
+derived from `attended / (attended + absent)`. This table is saved to your
+profile so information persists between game sessions.
 
 ### Syncing PlayerData
 
@@ -17,4 +18,5 @@ clients stay in sync.
 
 Use `/sl pm` in game to open the **Player Management** window. All fields of the
 `PlayerData` table can be edited directly in this window. Saving will broadcast
-the updated table to the raid.
+the updated table to the raid. Player data is stored in saved variables so any
+changes persist between sessions.

--- a/core.lua
+++ b/core.lua
@@ -100,11 +100,12 @@ function ScroogeLoot:OnInitialize()
 
 	-- Option table defaults
 	self.defaults = {
-		global = {
-			logMaxEntries = 500,
-			log = {}, -- debug log
-			localizedSubTypes = {},
-		},
+               global = {
+                       logMaxEntries = 500,
+                       log = {}, -- debug log
+                       localizedSubTypes = {},
+                       playerData = {},
+               },
 		profile = {
 			usage = { -- State of enabledness
 				ml = false,				-- Enable when ML
@@ -243,8 +244,12 @@ function ScroogeLoot:OnInitialize()
 
 	-- add shortcuts
 	db = self.db.profile
-	historyDB = self.lootDB.factionrealm
-	debugLog = self.db.global.log
+       historyDB = self.lootDB.factionrealm
+       debugLog = self.db.global.log
+
+       -- Load persisted PlayerData
+       self.PlayerData = self.db.global.playerData or {}
+       ScroogeLoot.PlayerData = self.PlayerData
 
 	-- register the optionstable
 	self.options = self:OptionsTable()

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -55,6 +55,9 @@ end
 
 -- Broadcast the complete PlayerData table to the raid.
 function addon:BroadcastPlayerData()
+    if self.db and self.db.global then
+        self.db.global.playerData = self.PlayerData
+    end
     if not self.isMasterLooter then return end
     -- Send to everyone in the current group/raid
     self:SendCommand("group", "playerData", self.PlayerData)


### PR DESCRIPTION
## Summary
- persist PlayerData in saved variables
- load existing PlayerData when initializing
- update docs about persistent player data

## Testing
- `luacheck` not available and `lua` interpreter missing

------
https://chatgpt.com/codex/tasks/task_e_6870d01eff5c8322aad6d291e0b82153