### PR TITLE
Auto-populate PlayerData from current group

### DIFF
--- a/Modules/playerManager.lua
+++ b/Modules/playerManager.lua
@@ -88,6 +88,9 @@ function SLPlayerManager:CreateOptionsUI(parent)
 end
 
 function SLPlayerManager:Show()
+    if not next(addon.PlayerData) then
+        addon:PopulatePlayerDataFromGroup()
+    end
     self.frame = self:GetFrame()
     self:LoadData(self.frame.content)
     self.frame:Show()

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -23,6 +23,33 @@ local function EnsurePlayer(name)
     end
 end
 
+-- expose helper
+addon.EnsurePlayer = EnsurePlayer
+
+--- Populate PlayerData with members of the current group/raid
+function addon:PopulatePlayerDataFromGroup()
+    local function addUnit(unit)
+        local name = UnitName(unit)
+        if name then
+            local _, class = UnitClass(unit)
+            EnsurePlayer(name)
+            self.PlayerData[name].class = class
+        end
+    end
+
+    if self:IsInRaid() then
+        for i = 1, self:GetNumGroupMembers() do
+            addUnit("raid" .. i)
+        end
+    elseif self:IsInGroup() then
+        for i = 1, self:GetNumGroupMembers() do
+            addUnit("party" .. i)
+        end
+    end
+
+    addUnit("player")
+end
+
 -- Update an arbitrary field on a player. Only works for the master looter.
 function addon:SetPlayerField(name, field, value)
     if not self.isMasterLooter then return end


### PR DESCRIPTION
## Summary
- expose `EnsurePlayer` helper and add `PopulatePlayerDataFromGroup`
- populate roster when Player Manager opens so the table is not empty

## Testing
- `luac` command was unavailable so syntax checks couldn't be run

------
https://chatgpt.com/codex/tasks/task_e_6870e3076c5483228308177ed450966e