### PR TITLE
Fix unclear message in voting frame

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -528,7 +528,8 @@ function SLVotingFrame:GetFrame()
 
 	local iTxt = f.content:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
 	iTxt:SetPoint("TOPLEFT", item, "TOPRIGHT", 10, 0)
-	iTxt:SetText(L["Something went wrong :'("]) -- Set text for reasons
+       -- Display a clearer message when no session is active
+       iTxt:SetText(L["No session running"]) -- Set text for reasons
 	f.itemText = iTxt
 
 	local ilvl = f.content:CreateFontString(nil, "OVERLAY", "GameFontNormal")


### PR DESCRIPTION
## Summary
- clarify the initial text on the voting frame

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871089bd3b08322a62ce406cf566718