### PR TITLE
Fix candidate sync and update PlayerData

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -165,8 +165,8 @@ function SLVotingFrame:OnCommReceived(prefix, serializedMsg, distri, sender)
 					self:SwitchSession(session) -- Use switch session to update awardstring
 				end
 
-			elseif command == "candidates" and addon:UnitIsUnit(sender, addon.masterLooter) then
-				candidates = unpack(data)
+                        elseif command == "candidates" and addon:UnitIsUnit(sender, addon.masterLooter) then
+                                self:UpdateCandidateList(unpack(data))
 
 			elseif command == "offline_timer" and addon:UnitIsUnit(sender, addon.masterLooter) then
 				for i = 1, #lootTable do
@@ -372,7 +372,47 @@ function SLVotingFrame:BuildST()
 		}
 		i = i + 1
 	end
-	self.frame.st:SetData(rows)
+        self.frame.st:SetData(rows)
+end
+
+-- Update candidate tables while a session is active
+function SLVotingFrame:UpdateCandidateList(new)
+        candidates = new
+        if not active or not lootTable or #lootTable == 0 then return end
+        for _, t in ipairs(lootTable) do
+                for name, data in pairs(new) do
+                        if not t.candidates[name] then
+                                t.candidates[name] = {
+                                        class = data.class,
+                                        rank = data.rank,
+                                        role = data.role,
+                                        raiderrank = data.raiderrank,
+                                        attendance = data.attendance,
+                                        response = "ANNOUNCED",
+                                        gear1 = nil,
+                                        gear2 = nil,
+                                        votes = 0,
+                                        note = nil,
+                                        roll = "",
+                                        voters = {},
+                                        haveVoted = false,
+                                }
+                        else
+                                t.candidates[name].class = data.class
+                                t.candidates[name].rank = data.rank
+                                t.candidates[name].role = data.role
+                                t.candidates[name].raiderrank = data.raiderrank
+                                t.candidates[name].attendance = data.attendance
+                        end
+                end
+                for name in pairs(t.candidates) do
+                        if not new[name] then
+                                t.candidates[name] = nil
+                        end
+                end
+        end
+        self:BuildST()
+        self:SwitchSession(session)
 end
 
 function SLVotingFrame:UpdateMoreInfo(row, data)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -165,8 +165,11 @@ function ScroogeLootML:UpdateGroup(ask)
 	for name, v in pairs(group_copy) do
 		if v then self:RemoveCandidate(name); updates = true end
 	end
-	if updates then
-		addon:SendCommand("group", "candidates", self.candidates) 
+        if updates then
+                -- keep PlayerData in sync with current group
+                addon:PopulatePlayerDataFromGroup()
+                addon:BroadcastPlayerData()
+                addon:SendCommand("group", "candidates", self.candidates)
 
 		local oldCouncil = self.council 
 		self.council = addon:GetCouncilInGroup()


### PR DESCRIPTION
## Summary
- keep PlayerData synchronized when the raid roster changes
- rebuild candidate lists if the master looter sends updates during a session

## Testing
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687145bfb9788322b1f7ddc9d40bf53b