### PR TITLE
Update player data when raid roster changes

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -272,7 +272,8 @@ function ScroogeLoot:OnEnable()
 	-- register events
 	self:RegisterEvent("PARTY_LOOT_METHOD_CHANGED", "OnEvent")
 	self:RegisterEvent("GUILD_ROSTER_UPDATE","OnEvent")
-	self:RegisterEvent("RAID_INSTANCE_WELCOME","OnEvent")
+        self:RegisterEvent("RAID_INSTANCE_WELCOME","OnEvent")
+        self:RegisterEvent("RAID_ROSTER_UPDATE","OnEvent")
 	self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnEvent")
 	self:RegisterEvent("PLAYER_REGEN_DISABLED", "EnterCombat")
 	self:RegisterEvent("PLAYER_REGEN_ENABLED", "LeaveCombat")
@@ -319,8 +320,11 @@ function ScroogeLoot:OnEnable()
 		self.db.global.log = {}
 	end
 
-	self.db.global.tVersion = self.tVersion;
-	GuildRoster()
+        self.db.global.tVersion = self.tVersion;
+        GuildRoster()
+
+        -- Initialize PlayerData for current group
+        self:PopulatePlayerDataFromGroup()
 
 	local filterFunc = function(_, event, msg, player, ...)
 		return strfind(msg, "[[ScroogeLoot]]:")
@@ -1253,9 +1257,13 @@ function ScroogeLoot:OnEvent(event, ...)
 		self:Debug("Event:", event, ...)
 		self:NewMLCheck()
 
-	elseif event == "RAID_ROSTER_UPDATE" then
-		self:Debug("Event:", event, ...)
-		self:NewMLCheck()
+        elseif event == "RAID_ROSTER_UPDATE" then
+                self:Debug("Event:", event, ...)
+                self:NewMLCheck()
+                local changed = self:PopulatePlayerDataFromGroup()
+                if changed then
+                        self:BroadcastPlayerData()
+                end
 
 	elseif event == "RAID_INSTANCE_WELCOME" then
 		self:Debug("Event:", event, ...)

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -28,11 +28,16 @@ addon.EnsurePlayer = EnsurePlayer
 
 --- Populate PlayerData with members of the current group/raid
 function addon:PopulatePlayerDataFromGroup()
+    local changed = false
+
     local function addUnit(unit)
         local name = UnitName(unit)
         if name then
             local _, class = UnitClass(unit)
-            EnsurePlayer(name)
+            if not self.PlayerData[name] then
+                EnsurePlayer(name)
+                changed = true
+            end
             self.PlayerData[name].class = class
         end
     end
@@ -48,6 +53,8 @@ function addon:PopulatePlayerDataFromGroup()
     end
 
     addUnit("player")
+
+    return changed
 end
 
 -- Update an arbitrary field on a player. Only works for the master looter.


### PR DESCRIPTION
## Summary
- track roster changes with `RAID_ROSTER_UPDATE`
- create missing player entries when the roster changes
- initialize PlayerData on addon enable

## Testing
- `luac -p playerdata.lua`
- `luac -p core.lua`
- `apt-get update`
- `apt-get install -y lua5.1`

------
https://chatgpt.com/codex/tasks/task_e_68714b2851508322a2064c4b419b8e71