### PR TITLE
Fix roll button

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -33,6 +33,7 @@ local function CanEquipItem(name, item) return true end
 
 -- Handles rolling logic for the custom buttons
 function HandleRollClick(playerName, rollType, sessionID, item)
+  addon.EnsurePlayer(playerName)
   local p = addon.PlayerData and addon.PlayerData[playerName]
   if not p then return end
 


### PR DESCRIPTION
## Summary
- ensure player data exists when rolling

## Testing
- `luac -p Modules/lootFrame.lua`
- `find Modules -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: unexpected symbol near '')*

------
https://chatgpt.com/codex/tasks/task_e_6871508e9e208322b8f1bbff21d4f3d0