### PR TITLE
Add candidateData table for raid members

### DIFF
--- a/Modules/playerManager.lua
+++ b/Modules/playerManager.lua
@@ -1,4 +1,4 @@
--- PlayerManager module for editing PlayerData
+-- PlayerManager module for editing candidateData
 local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
 local SLPlayerManager = addon:NewModule("SLPlayerManager")
 local ST = LibStub("ScrollingTable")
@@ -88,8 +88,8 @@ function SLPlayerManager:CreateOptionsUI(parent)
 end
 
 function SLPlayerManager:Show()
-    if not next(addon.PlayerData) then
-        addon:PopulatePlayerDataFromGroup()
+    if not next(addon.candidateData) then
+        addon:PopulateCandidateDataFromGroup()
     end
     self.frame = self:GetFrame()
     self:LoadData(self.frame.content)
@@ -104,7 +104,7 @@ end
 function SLPlayerManager:LoadData(target)
     local t = target or self.frame.content
     t.rows = {}
-    for name,data in pairs(addon.PlayerData) do
+    for name,data in pairs(addon.candidateData) do
         local copy = {}
         for k,v in pairs(data) do copy[k] = v end
         copy.name = name
@@ -161,7 +161,7 @@ end
 
 function SLPlayerManager:Save(target)
     local t = target or self.frame.content
-    wipe(addon.PlayerData)
+    wipe(addon.candidateData)
     for _,row in ipairs(t.rows) do
         local d = row.data
         local pd = {
@@ -185,10 +185,10 @@ function SLPlayerManager:Save(target)
             pd.attendance = 100
         end
         local name = d.name or row.name
-        addon.PlayerData[name] = pd
+        addon.candidateData[name] = pd
         row.name = name
     end
-    addon:BroadcastPlayerData()
+    addon:BroadcastCandidateData()
     addon:Print(L["Player Management"]..": "..L["Save"].."!")
 end
 
@@ -200,12 +200,12 @@ local function Escape(str)
 end
 
 function SLPlayerManager:Export()
-    local xml = "<PlayerData>\n"
-    for name,data in pairs(addon.PlayerData) do
+    local xml = "<candidateData>\n"
+    for name,data in pairs(addon.candidateData) do
         xml = xml .. string.format('<Player name="%s" class="%s" raider="%s" SP="%s" DP="%s" attended="%s" absent="%s" item1="%s" item1received="%s" item2="%s" item2received="%s" item3="%s" item3received="%s"/>\n',
             Escape(name), Escape(data.class), tostring(data.raiderrank or false), tostring(data.SP or 0), tostring(data.DP or 0), tostring(data.attended or 0), tostring(data.absent or 0), Escape(data.item1), tostring(data.item1received or false), Escape(data.item2), tostring(data.item2received or false), Escape(data.item3), tostring(data.item3received or false))
     end
-    xml = xml .. "</PlayerData>"
+    xml = xml .. "</candidateData>"
     StaticPopup_Show("SLPLAYERMANAGER_EXPORT", nil, nil, xml)
 end
 
@@ -243,8 +243,8 @@ function SLPlayerManager:ImportData(text)
         end
     end
     if next(newData) then
-        addon.PlayerData = newData
-        addon:BroadcastPlayerData()
+        addon.candidateData = newData
+        addon:BroadcastCandidateData()
         if self.frame and self.frame.content then
             self:LoadData(self.frame.content)
             self.frame.content.st:SetData(self.frame.content.rows)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # ScroogeLoot
 addon for loot management for Epoch WoW
 
-## Player Data
+## Candidate Data
 
-The addon maintains a `PlayerData` table containing raid member information.
+The addon maintains a `candidateData` table containing raid member information.
 Only the master looter is allowed to modify the table. Attendance percentage is
 derived from `attended / (attended + absent)`. This table is saved to your
 profile so information persists between game sessions.
 
-### Syncing PlayerData
+### Syncing candidateData
 
 The master looter's copy is the source of truth. Whenever the master updates
-`PlayerData`, the new table is broadcast to the group using AceComm so that all
+`candidateData`, the new table is broadcast to the group using AceComm so that all
 clients stay in sync.
 
-### Editing PlayerData
+### Editing candidateData
 
 Use `/sl pm` in game to open the **Player Management** window. All fields of the
-`PlayerData` table can be edited directly in this window. Saving will broadcast
+`candidateData` table can be edited directly in this window. Saving will broadcast
 the updated table to the raid. Player data is stored in saved variables so any
 changes persist between sessions.

--- a/ScroogeLoot.toc
+++ b/ScroogeLoot.toc
@@ -12,6 +12,7 @@ Locale\Locales.xml
 core.lua
 ml_core.lua
 compat.lua
+candidateData.lua
 Modules\Modules.xml
 
 Utils\tokenData.lua

--- a/candidateData.lua
+++ b/candidateData.lua
@@ -1,14 +1,16 @@
--- PlayerData holds raid member information such as class and attendance.
--- Only the master looter may modify the table.
 
-local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
+-- candidateData holds raid member information used when evaluating loot
+-- candidates. Only the master looter may modify the table.
 
-addon.PlayerData = addon.PlayerData or {}
+local SL = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
+
+SL.candidateData = SL.candidateData or {}
 
 -- Creates entry for player if not present
-local function EnsurePlayer(name)
-    if not addon.PlayerData[name] then
-        addon.PlayerData[name] = {
+local function EnsureCandidate(name)
+    if not SL.candidateData[name] then
+        SL.candidateData[name] = {
+            name = name,
             class = "",
             raiderrank = false,
             SP = 0,
@@ -24,16 +26,16 @@ local function EnsurePlayer(name)
 end
 
 -- expose helper
-addon.EnsurePlayer = EnsurePlayer
+SL.EnsureCandidate = EnsureCandidate
 
---- Populate PlayerData with members of the current group/raid
-function addon:PopulatePlayerDataFromGroup()
+--- Populate candidateData with members of the current group/raid
+function SL:PopulateCandidateDataFromGroup()
     local function addUnit(unit)
         local name = UnitName(unit)
         if name then
             local _, class = UnitClass(unit)
-            EnsurePlayer(name)
-            self.PlayerData[name].class = class
+            EnsureCandidate(name)
+            self.candidateData[name].class = class
         end
     end
 
@@ -51,18 +53,18 @@ function addon:PopulatePlayerDataFromGroup()
 end
 
 -- Update an arbitrary field on a player. Only works for the master looter.
-function addon:SetPlayerField(name, field, value)
+function SL:SetCandidateField(name, field, value)
     if not self.isMasterLooter then return end
-    EnsurePlayer(name)
-    self.PlayerData[name][field] = value
-    self:BroadcastPlayerData()
+    EnsureCandidate(name)
+    self.candidateData[name][field] = value
+    self:BroadcastCandidateData()
 end
 
 -- Increment attendance values and update derived attendance field.
-function addon:ModifyAttendance(name, attendedInc, absentInc)
+function SL:ModifyAttendance(name, attendedInc, absentInc)
     if not self.isMasterLooter then return end
-    EnsurePlayer(name)
-    local data = self.PlayerData[name]
+    EnsureCandidate(name)
+    local data = self.candidateData[name]
     data.attended = (data.attended or 0) + (attendedInc or 0)
     data.absent = (data.absent or 0) + (absentInc or 0)
     local total = data.attended + data.absent
@@ -71,22 +73,22 @@ function addon:ModifyAttendance(name, attendedInc, absentInc)
     else
         data.attendance = 100
     end
-    self:BroadcastPlayerData()
+    self:BroadcastCandidateData()
 end
 
 -- Retrieve a player's data table (read only)
-function addon:GetPlayerData(name)
-    EnsurePlayer(name)
-    return self.PlayerData[name]
+function SL:GetCandidateData(name)
+    EnsureCandidate(name)
+    return self.candidateData[name]
 end
 
--- Broadcast the complete PlayerData table to the raid.
-function addon:BroadcastPlayerData()
+-- Broadcast the complete candidateData table to the raid.
+function SL:BroadcastCandidateData()
     if self.db and self.db.global then
-        self.db.global.playerData = self.PlayerData
+        self.db.global.candidateData = self.candidateData
     end
     if not self.isMasterLooter then return end
     -- Send to everyone in the current group/raid
-    self:SendCommand("group", "playerData", self.PlayerData)
+    self:SendCommand("group", "candidateData", self.candidateData)
 end
 


### PR DESCRIPTION
## Summary
- add new `candidateData` table for raid members
- switch player management module and docs to reference `candidateData`
- load new file in `ScroogeLoot.toc`

## Testing
- `luacheck` and `luarocks` were not available in the container

------
https://chatgpt.com/codex/tasks/task_e_6873f8429f308322b30a34ab866e459a