### PR TITLE
Initialize player entry and document location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ Use `/sl pm` in game to open the **Player Management** window. All fields of the
 `PlayerData` table can be edited directly in this window. Saving will broadcast
 the updated table to the raid. Player data is stored in saved variables so any
 changes persist between sessions.
+
+The saved data is written to `ScroogeLootDB` which lives in your
+`WTF/Account/<ACCOUNT>/SavedVariables/ScroogeLoot.lua` file. If the file or your
+character entry does not exist, the addon will create it the first time you log
+in and automatically add your character to the table.

--- a/core.lua
+++ b/core.lua
@@ -325,6 +325,11 @@ function ScroogeLoot:OnEnable()
 
         -- Initialize PlayerData for current group
         self:PopulatePlayerDataFromGroup()
+        -- Ensure the current player has an entry saved
+        if not self.PlayerData[self.playerName] then
+                self:EnsurePlayer(self.playerName)
+                self:BroadcastPlayerData()
+        end
 
 	local filterFunc = function(_, event, msg, player, ...)
 		return strfind(msg, "[[ScroogeLoot]]:")


### PR DESCRIPTION
## Summary
- add code to create the player's `PlayerData` entry on login
- document where the saved variables file is stored and note automatic creation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d7c946c48322a51d95efa9468f3a