### PR TITLE
Save player data to a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use `/sl pm` in game to open the **Player Management** window. All fields of the
 the updated table to the raid. Player data is stored in saved variables so any
 changes persist between sessions.
 
-The saved data is written to `ScroogeLootDB` which lives in your
-`WTF/Account/<ACCOUNT>/SavedVariables/ScroogeLoot.lua` file. If the file or your
-character entry does not exist, the addon will create it the first time you log
-in and automatically add your character to the table.
+The saved data is written to `ScroogeLootPlayerDB` which lives in its own file
+`WTF/Account/<ACCOUNT>/SavedVariables/ScroogeLootPlayerDB.lua`. If the file or
+your character entry does not exist, the addon will create it the first time you
+log in and automatically add your character to the table.

--- a/ScroogeLoot.toc
+++ b/ScroogeLoot.toc
@@ -3,7 +3,7 @@
 ## Notes: Interface for running a Loot Council backported to 3.3.5a
 ## Title: ScroogeLoot
 ## Version: 2.0.4
-## SavedVariables: ScroogeLootDB, ScroogeLootLootDB
+## SavedVariables: ScroogeLootDB, ScroogeLootLootDB, ScroogeLootPlayerDB
 ## OptionalDeps: LibStub, CallbackHandler-1.0, Ace3, lib-st, LibWindow-1.1, LibDialog-1.0
 
 embeds.xml

--- a/core.lua
+++ b/core.lua
@@ -231,8 +231,9 @@ function ScroogeLoot:OnInitialize()
        self:RegisterChatCommand("rclc", "ChatCommand")
 	self:RegisterComm("ScroogeLoot")
 	self:RegisterComm("ScroogeLoot_WotLK")
-	self.db = LibStub("AceDB-3.0"):New("ScroogeLootDB", self.defaults, true)
-	self.lootDB = LibStub("AceDB-3.0"):New("ScroogeLootLootDB")
+       self.db = LibStub("AceDB-3.0"):New("ScroogeLootDB", self.defaults, true)
+       self.lootDB = LibStub("AceDB-3.0"):New("ScroogeLootLootDB")
+       self.playerDB = LibStub("AceDB-3.0"):New("ScroogeLootPlayerDB", {global={playerData={}}})
 	--[[ Format:
 	"playerName" = {
 		[#] = {"lootWon", "date (d/m/y)", "time (h:m:s)", "instance", "boss", "votes", "itemReplaced1", "itemReplaced2", "response", "responseID", "color", "class", "isAwardReason"}
@@ -248,7 +249,7 @@ function ScroogeLoot:OnInitialize()
        debugLog = self.db.global.log
 
        -- Load persisted PlayerData
-       self.PlayerData = self.db.global.playerData or {}
+       self.PlayerData = self.playerDB.global.playerData or {}
        ScroogeLoot.PlayerData = self.PlayerData
 
 	-- register the optionstable
@@ -748,10 +749,13 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 
 			elseif command == "playerData" then
 				-- Update local PlayerData from the master looter
-				if not self.isMasterLooter then
-					local incomingData = unpack(data)
-					self.PlayerData = incomingData
-				end
+                                if not self.isMasterLooter then
+                                        local incomingData = unpack(data)
+                                        self.PlayerData = incomingData
+                                        if self.playerDB and self.playerDB.global then
+                                                self.playerDB.global.playerData = incomingData
+                                        end
+                                end
 			elseif command == "message" then
 				self:Print(unpack(data))
 

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -89,8 +89,8 @@ end
 
 -- Broadcast the complete PlayerData table to the raid.
 function addon:BroadcastPlayerData()
-    if self.db and self.db.global then
-        self.db.global.playerData = self.PlayerData
+    if self.playerDB and self.playerDB.global then
+        self.playerDB.global.playerData = self.PlayerData
     end
     if not self.isMasterLooter then return end
     -- Send to everyone in the current group/raid


### PR DESCRIPTION
## Summary
- store player data in its own SavedVariable table `ScroogeLootPlayerDB`
- update broadcasts to write to the new DB
- persist received player data
- document new file location

## Testing
- `luac -p core.lua`
- `luac -p playerdata.lua`


------
https://chatgpt.com/codex/tasks/task_e_687555caedb08322a174b0c45d8f5ce8