### PR TITLE
Use PlayerDB for voting frame data

### DIFF
--- a/Modules/playerManager.lua
+++ b/Modules/playerManager.lua
@@ -165,6 +165,7 @@ function SLPlayerManager:Save(target)
     for _,row in ipairs(t.rows) do
         local d = row.data
         local pd = {
+            name = d.name or row.name,
             class = d.class,
             raiderrank = d.raiderrank,
             SP = tonumber(d.SP) or 0,
@@ -184,7 +185,7 @@ function SLPlayerManager:Save(target)
         else
             pd.attendance = 100
         end
-        local name = d.name or row.name
+        local name = pd.name
         addon.PlayerData[name] = pd
         row.name = name
     end
@@ -202,8 +203,9 @@ end
 function SLPlayerManager:Export()
     local xml = "<PlayerData>\n"
     for name,data in pairs(addon.PlayerData) do
+        local n = data.name or name
         xml = xml .. string.format('<Player name="%s" class="%s" raider="%s" SP="%s" DP="%s" attended="%s" absent="%s" item1="%s" item1received="%s" item2="%s" item2received="%s" item3="%s" item3received="%s"/>\n',
-            Escape(name), Escape(data.class), tostring(data.raiderrank or false), tostring(data.SP or 0), tostring(data.DP or 0), tostring(data.attended or 0), tostring(data.absent or 0), Escape(data.item1), tostring(data.item1received or false), Escape(data.item2), tostring(data.item2received or false), Escape(data.item3), tostring(data.item3received or false))
+            Escape(n), Escape(data.class), tostring(data.raiderrank or false), tostring(data.SP or 0), tostring(data.DP or 0), tostring(data.attended or 0), tostring(data.absent or 0), Escape(data.item1), tostring(data.item1received or false), Escape(data.item2), tostring(data.item2received or false), Escape(data.item3), tostring(data.item3received or false))
     end
     xml = xml .. "</PlayerData>"
     StaticPopup_Show("SLPLAYERMANAGER_EXPORT", nil, nil, xml)
@@ -244,6 +246,9 @@ function SLPlayerManager:ImportData(text)
     end
     if next(newData) then
         addon.PlayerData = newData
+        if addon.EnsureNameFields then
+            addon:EnsureNameFields()
+        end
         addon:BroadcastPlayerData()
         if self.frame and self.frame.content then
             self:LoadData(self.frame.content)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -232,8 +232,8 @@ function SLVotingFrame:Setup(table)
                                class = v.class,
                                rank = v.rank,
                                role = v.role,
-                               raiderrank = v.raiderrank,
-                               attendance = v.attendance,
+                               raiderrank = addon:GetPlayerData(name).raiderrank,
+                               attendance = addon:GetPlayerData(name).attendance,
                                response = "ANNOUNCED",
                                gear1 = nil,
                                gear2 = nil,
@@ -755,14 +755,14 @@ end
 
 function SLVotingFrame.SetCellRaider(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
        local name = data[realrow].name
-       local val = lootTable[session].candidates[name].raiderrank
+       local val = addon:GetPlayerData(name).raiderrank
        frame.text:SetText(RaiderText(val))
        data[realrow].cols[column].value = val and 1 or 0
 end
 
 function SLVotingFrame.SetCellAttendance(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
        local name = data[realrow].name
-       local val = lootTable[session].candidates[name].attendance or ""
+       local val = addon:GetPlayerData(name).attendance or ""
        frame.text:SetText(tostring(val))
        data[realrow].cols[column].value = tonumber(val) or 0
 end

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ The saved data is written to `ScroogeLootPlayerDB` which lives in its own file
 `WTF/Account/<ACCOUNT>/SavedVariables/ScroogeLootPlayerDB.lua`. If the file or
 your character entry does not exist, the addon will create it the first time you
 log in and automatically add your character to the table.
+
+Each player entry in `PlayerData` contains the following fields:
+
+```
+name, class, raiderrank, DP, SP,
+item1, item1received, item2, item2received,
+item3, item3received, attended, absent, attendance
+```

--- a/core.lua
+++ b/core.lua
@@ -251,6 +251,9 @@ function ScroogeLoot:OnInitialize()
        -- Load persisted PlayerData
        self.PlayerData = self.playerDB.global.playerData or {}
        ScroogeLoot.PlayerData = self.PlayerData
+       if self.EnsureNameFields then
+               self:EnsureNameFields()
+       end
 
 	-- register the optionstable
 	self.options = self:OptionsTable()
@@ -752,6 +755,9 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
                                 if not self.isMasterLooter then
                                         local incomingData = unpack(data)
                                         self.PlayerData = incomingData
+                                        if self.EnsureNameFields then
+                                                self:EnsureNameFields()
+                                        end
                                         if self.playerDB and self.playerDB.global then
                                                 self.playerDB.global.playerData = incomingData
                                         end

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -9,6 +9,7 @@ addon.PlayerData = addon.PlayerData or {}
 local function EnsurePlayer(name)
     if not addon.PlayerData[name] then
         addon.PlayerData[name] = {
+            name = name,
             class = "",
             raiderrank = false,
             SP = 0,
@@ -20,6 +21,17 @@ local function EnsurePlayer(name)
             item2 = nil, item2received = false,
             item3 = nil, item3received = false,
         }
+    elseif not addon.PlayerData[name].name then
+        addon.PlayerData[name].name = name
+    end
+end
+
+-- Ensure all entries have their name field set
+function addon:EnsureNameFields()
+    for n, data in pairs(self.PlayerData) do
+        if not data.name then
+            data.name = n
+        end
     end
 end
 


### PR DESCRIPTION
## Summary
- fetch raid rank and attendance from the player database when populating voting candidates
- reference PlayerDB values in voting frame cells so updates persist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68760def1c1c8322b0a261acfe55db25