### PR TITLE
Add Player Management options tab

### DIFF
--- a/Modules/AceGUIWidget-SLPlayerManager.lua
+++ b/Modules/AceGUIWidget-SLPlayerManager.lua
@@ -1,0 +1,44 @@
+local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
+local AceGUI = LibStub("AceGUI-3.0")
+
+local Type, Version = "SLPlayerManager", 1
+
+local methods = {}
+
+function methods:OnAcquire()
+    if not self.created then
+        local pm = addon:GetModule("SLPlayerManager", true)
+        if pm then
+            pm:CreateOptionsUI(self.content)
+            pm:LoadData(self.content)
+            self.content.st:SetData(self.content.rows)
+        end
+        self.created = true
+    end
+end
+
+function methods:OnRelease()
+    local pm = addon:GetModule("SLPlayerManager", true)
+    if pm and pm.optionsFrame == self.content then
+        pm.optionsFrame = nil
+    end
+    self.created = nil
+end
+
+local function Constructor()
+    local frame = CreateFrame("Frame")
+    local content = CreateFrame("Frame", nil, frame)
+    content:SetAllPoints()
+
+    local widget = {
+        frame = frame,
+        content = content,
+        type = Type,
+    }
+    for k, v in pairs(methods) do
+        widget[k] = v
+    end
+    return AceGUI:RegisterAsContainer(widget)
+end
+
+AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/Modules/Modules.xml
+++ b/Modules/Modules.xml
@@ -4,6 +4,7 @@
   <Script file = "votingFrame.lua" />
   <Script file = "sessionFrame.lua" />
   <Script file = "playerManager.lua" />
+  <Script file = "AceGUIWidget-SLPlayerManager.lua" />
   <Script file = "options.lua" />
   <Script file = "lootHistory.lua" />
 </Ui>

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ clients stay in sync.
 
 ### Editing PlayerData
 
-Use `/sl pm` in game to open the **Player Management** window. All fields of the
-`PlayerData` table can be edited directly in this window. Saving will broadcast
-the updated table to the raid. Player data is stored in saved variables so any
-changes persist between sessions.
+Use `/sl pm` in game to open the **Player Management** window or open the **Player
+Management** tab from the addon options. All fields of the `PlayerData` table
+can be edited directly in this window. Saving will broadcast the updated table
+to the raid. Player data is stored in saved variables so any changes persist
+between sessions.
 
 The saved data is written to `ScroogeLootPlayerDB` which lives in its own file
 `WTF/Account/<ACCOUNT>/SavedVariables/ScroogeLootPlayerDB.lua`. If the file or

--- a/core.lua
+++ b/core.lua
@@ -261,8 +261,9 @@ function ScroogeLoot:OnInitialize()
 	LibStub("AceConfigRegistry-3.0"):RegisterOptionsTable("ScroogeLoot", self.options)
 
 	-- add it to blizz options
-	self.optionsFrame = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("ScroogeLoot", "ScroogeLoot", nil, "settings")
-	self.optionsFrame.ml = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("ScroogeLoot", "Master Looter", "ScroogeLoot", "mlSettings")
+    self.optionsFrame = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("ScroogeLoot", "ScroogeLoot", nil, "settings")
+    self.optionsFrame.ml = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("ScroogeLoot", "Master Looter", "ScroogeLoot", "mlSettings")
+    self.optionsFrame.pm = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("ScroogeLoot", L["Player Management"], "ScroogeLoot", "mlSettings", "PlayerDataManagement")
 	-- Add logged in message in the log
 	self:DebugLog("Logged In")
 end


### PR DESCRIPTION
## Summary
- expose player management through addon options
- create AceGUI widget for the player management table
- register the widget in Modules.xml so it loads
- document the options tab in README

## Testing
- `luac -p Modules/AceGUIWidget-SLPlayerManager.lua`
- `luac -p core.lua`

------
https://chatgpt.com/codex/tasks/task_e_68766e241ac48322aedec8881c173aa7