### PR TITLE
Add editable player data widget

### DIFF
--- a/Modules/AceGUIWidget-SLPlayerManager.lua
+++ b/Modules/AceGUIWidget-SLPlayerManager.lua
@@ -1,0 +1,39 @@
+local Type, Version = "SLPlayerManager", 1
+local AceGUI = LibStub("AceGUI-3.0")
+local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
+
+local function OnAcquire(self)
+    if not self.created then
+        local pm = addon:GetModule("SLPlayerManager", true)
+        if pm then
+            pm:CreateOptionsUI(self.frame)
+            self.created = true
+        end
+    end
+    local pm = addon:GetModule("SLPlayerManager", true)
+    if pm then
+        pm:LoadData(self.frame)
+        if self.frame.st then
+            self.frame.st:SetData(self.frame.rows)
+        end
+    end
+end
+
+local function OnRelease(self)
+end
+
+local methods = {
+    ["OnAcquire"] = OnAcquire,
+    ["OnRelease"] = OnRelease,
+}
+
+local function Constructor()
+    local frame = CreateFrame("Frame", nil, UIParent)
+    local widget = { frame = frame, type = Type }
+    for method, func in pairs(methods) do
+        widget[method] = func
+    end
+    return AceGUI:RegisterAsContainer(widget)
+end
+
+AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/Modules/Modules.xml
+++ b/Modules/Modules.xml
@@ -4,6 +4,7 @@
   <Script file = "votingFrame.lua" />
   <Script file = "sessionFrame.lua" />
   <Script file = "playerManager.lua" />
+  <Script file = "AceGUIWidget-SLPlayerManager.lua" />
   <Script file = "options.lua" />
   <Script file = "lootHistory.lua" />
 </Ui>


### PR DESCRIPTION
## Summary
- implement `SLPlayerManager` AceGUI widget so options panel can display editable player data
- load new widget in `Modules.xml`

## Testing
- `luac -p Modules/AceGUIWidget-SLPlayerManager.lua`
- `luac -p Modules/playerManager.lua`


------
https://chatgpt.com/codex/tasks/task_e_687687a6a5bc83228a64ed408052a732