### PR TITLE
Rename saved variable to PlayerDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Use `/sl pm` in game to open the **Player Management** window. All fields of the
 the updated table to the raid. Player data is stored in saved variables so any
 changes persist between sessions.
 
-The saved data is written to `ScroogeLootPlayerDB` which lives in its own file
-`WTF/Account/<ACCOUNT>/SavedVariables/ScroogeLootPlayerDB.lua`. If the file or
+The saved data is written to `PlayerDB` which lives in its own file
+`WTF/Account/<ACCOUNT>/SavedVariables/PlayerDB.lua`. If the file or
 your character entry does not exist, the addon will create it the first time you
 log in and automatically add your character to the table.
 

--- a/ScroogeLoot.toc
+++ b/ScroogeLoot.toc
@@ -3,7 +3,7 @@
 ## Notes: Interface for running a Loot Council backported to 3.3.5a
 ## Title: ScroogeLoot
 ## Version: 2.0.4
-## SavedVariables: ScroogeLootDB, ScroogeLootLootDB, ScroogeLootPlayerDB
+## SavedVariables: ScroogeLootDB, ScroogeLootLootDB, PlayerDB
 ## OptionalDeps: LibStub, CallbackHandler-1.0, Ace3, lib-st, LibWindow-1.1, LibDialog-1.0
 
 embeds.xml

--- a/core.lua
+++ b/core.lua
@@ -233,7 +233,7 @@ function ScroogeLoot:OnInitialize()
 	self:RegisterComm("ScroogeLoot_WotLK")
        self.db = LibStub("AceDB-3.0"):New("ScroogeLootDB", self.defaults, true)
        self.lootDB = LibStub("AceDB-3.0"):New("ScroogeLootLootDB")
-       self.playerDB = LibStub("AceDB-3.0"):New("ScroogeLootPlayerDB", {global={playerData={}}})
+       self.playerDB = LibStub("AceDB-3.0"):New("PlayerDB", {global={playerData={}}})
 	--[[ Format:
 	"playerName" = {
 		[#] = {"lootWon", "date (d/m/y)", "time (h:m:s)", "instance", "boss", "votes", "itemReplaced1", "itemReplaced2", "response", "responseID", "color", "class", "isAwardReason"}

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -112,11 +112,11 @@ end
 
 -- Simple player registration and attendance update
 local addonName = ...
-scroogelootplayerDB = scroogelootplayerDB or {}
+PlayerDB = PlayerDB or {}
 
 local function InitializePlayerData(playerName, class)
-    if not scroogelootplayerDB[playerName] then
-        scroogelootplayerDB[playerName] = {
+    if not PlayerDB[playerName] then
+        PlayerDB[playerName] = {
             name = playerName,
             class = class,
             raiderrank = false,
@@ -133,7 +133,7 @@ local function InitializePlayerData(playerName, class)
             item3received = false,
         }
     else
-        local player = scroogelootplayerDB[playerName]
+        local player = PlayerDB[playerName]
         local keepFields = {
             name = true, class = true, raiderrank = true,
             SP = true, DP = true, attended = true, absent = true, attendance = true,
@@ -157,7 +157,7 @@ local function InitializePlayerData(playerName, class)
 end
 
 local function UpdateAttendance(playerName)
-    local player = scroogelootplayerDB[playerName]
+    local player = PlayerDB[playerName]
     if not player then return end
     local total = player.attended + player.absent
     player.attendance = (total > 0) and math.floor((player.attended / total) * 100) or 0
@@ -174,6 +174,6 @@ SlashCmdList["SCROOGELOOT"] = function(msg)
     local name, class = UnitName("player"), select(2, UnitClass("player"))
     RegisterPlayer(name, class)
     print("Registered:", name)
-    print("Attendance:", scroogelootplayerDB[name].attendance .. "%")
+    print("Attendance:", PlayerDB[name].attendance .. "%")
 end
 


### PR DESCRIPTION
## Summary
- rename ScroogeLootPlayerDB references to PlayerDB
- update saved variable initializations and docs

## Testing
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687946283b3083229dfbaac4625fd508