### PR TITLE
Ensure voting uses PlayerDB

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -34,42 +34,44 @@ local function CanEquipItem(name, item) return true end
 -- Send the chosen roll option to the master looter. When executed by the master
 -- it will also generate and broadcast the roll result to the voting frame.
 local function OnRollOptionClick(playerName, rollType, sessionID)
-    if not addon.isMasterLooter then
-        addon:SendCommand(addon.masterLooter, "roll_choice", sessionID, playerName, rollType)
-        return
-    end
-
-    local playerData = PlayerDB and PlayerDB[playerName]
-    if not playerData then
+    local data = PlayerDB and PlayerDB[playerName]
+    if not data then
         local _, class = UnitClass(playerName)
         if RegisterPlayer then
             RegisterPlayer(playerName, class)
         end
-        playerData = PlayerDB and PlayerDB[playerName]
-        if not playerData then return end
+        data = PlayerDB and PlayerDB[playerName]
+    end
+    if not data then
+        print("Player not found in PlayerDB:", playerName)
+        return
     end
 
-    local baseRoll = math.random(1, 100)
-    local modifiedRoll = baseRoll
-
+    local rollValue = math.random(1, 100)
+    local sp = data.SP or 0
+    local dp = data.DP or 0
+    local adjustedRoll = rollValue
     if rollType == "SP" then
-        modifiedRoll = baseRoll + (playerData.SP or 0)
+        adjustedRoll = adjustedRoll + sp
     elseif rollType == "DP" then
-        modifiedRoll = baseRoll - (playerData.DP or 0)
+        adjustedRoll = adjustedRoll - dp
     end
 
-    local vf = addon:GetModule("SLVotingFrame")
-    vf:SetCandidateData(sessionID, playerName, "roll", modifiedRoll)
-    vf:SetCandidateData(sessionID, playerName, "rollInfo", {
-        base = baseRoll,
-        final = modifiedRoll,
-        SP = playerData.SP,
-        DP = playerData.DP,
-    })
-    if vf.frame and vf.frame.st then
-        vf.frame.st:Refresh()
+    local payload = string.format(
+        "ROLL:%s:%s:%s:%d:%d:%d:%d",
+        playerName,
+        data.class or "UNKNOWN",
+        rollType,
+        rollValue,
+        adjustedRoll,
+        sp,
+        dp
+    )
+    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
+        C_ChatInfo.SendAddonMessage("ScroogeLoot", payload, "RAID")
+    else
+        SendAddonMessage("ScroogeLoot", payload, "RAID")
     end
-    vf:Update()
 end
 
 function LootFrame:Start(table)

--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -48,24 +48,12 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
     end
 
     local rollValue = math.random(1, 100)
-    local sp = data.SP or 0
-    local dp = data.DP or 0
-    local adjustedRoll = rollValue
-    if rollType == "SP" then
-        adjustedRoll = adjustedRoll + sp
-    elseif rollType == "DP" then
-        adjustedRoll = adjustedRoll - dp
-    end
 
     local payload = string.format(
-        "ROLL:%s:%s:%s:%d:%d:%d:%d",
+        "ROLL:%s:%s:%d",
         playerName,
-        data.class or "UNKNOWN",
-        rollType,
-        rollValue,
-        adjustedRoll,
-        sp,
-        dp
+        rollType:lower(),
+        rollValue
     )
     if C_ChatInfo and C_ChatInfo.SendAddonMessage then
         C_ChatInfo.SendAddonMessage("ScroogeLoot", payload, "RAID")

--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -40,7 +40,14 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
     end
 
     local playerData = PlayerDB and PlayerDB[playerName]
-    if not playerData then return end
+    if not playerData then
+        local _, class = UnitClass(playerName)
+        if RegisterPlayer then
+            RegisterPlayer(playerName, class)
+        end
+        playerData = PlayerDB and PlayerDB[playerName]
+        if not playerData then return end
+    end
 
     local baseRoll = math.random(1, 100)
     local modifiedRoll = baseRoll

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -37,6 +37,13 @@ end
 -- Update a single voting row using PlayerDB data
 local function UpdateVotingRow(playerName)
     local data = PlayerDB and PlayerDB[playerName]
+    if not data then
+        local _, class = UnitClass(playerName)
+        if RegisterPlayer then
+            RegisterPlayer(playerName, class)
+        end
+        data = PlayerDB and PlayerDB[playerName]
+    end
     if not data or not SLVotingFrame.frame then return end
 
     local attendance = CalculateAttendance(data.attended, data.absent)
@@ -57,6 +64,13 @@ end
 -- Master looter only: handle an incoming roll choice and update the table
 local function HandleRollChoice(sessionID, playerName, rollType)
     local playerData = PlayerDB and PlayerDB[playerName]
+    if not playerData then
+        local _, class = UnitClass(playerName)
+        if RegisterPlayer then
+            RegisterPlayer(playerName, class)
+        end
+        playerData = PlayerDB and PlayerDB[playerName]
+    end
     if not playerData or not sessionID then return end
 
     local baseRoll = math.random(1, 100)

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -94,7 +94,19 @@ end
 
 function ScroogeLootML:AddCandidate(name, class, role, rank, enchant, lvl)
         addon:DebugLog("ML:AddCandidate", name, class, role, rank, enchant, lvl)
-        local pd = addon.PlayerData and addon.PlayerData[name] or {}
+        local pd = nil
+        if PlayerDB and PlayerDB[name] then
+                pd = PlayerDB[name]
+        elseif addon.PlayerData and addon.PlayerData[name] then
+                pd = addon.PlayerData[name]
+        end
+        if not pd then
+                local _, cls = UnitClass(name)
+                if RegisterPlayer then
+                        RegisterPlayer(name, cls)
+                end
+                pd = PlayerDB and PlayerDB[name] or {}
+        end
         self.candidates[name] = {
                 ["class"]       = class,
                 ["role"]        = role or "DAMAGER",

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -1,4 +1,4 @@
-﻿--[[	ScroogeLoot by Potdisc
+--[[	ScroogeLoot by Potdisc
 ml_core.lua	Contains core elements for the MasterLooter
 	-	Although possible, this module shouldn't be replaced unless closely replicated as other default modules depend on it.
 	-	Assumes several functions in SessionFrame and VotingFrame


### PR DESCRIPTION
## Summary
- ensure loot frame looks up or creates PlayerDB entry when rolling
- do the same in the voting frame when rolls are handled
- create PlayerDB entries when candidates are added to sessions

## Testing
- `luac -p Modules/lootFrame.lua`
- `luac -p Modules/votingFrame.lua`
- `luac -p ml_core.lua`
- `luac -p playerdata.lua`


------
https://chatgpt.com/codex/tasks/task_e_687c02c92784832292b2721690b57716