### PR TITLE
Add ShowCandidates helper

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -60,6 +60,11 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
     else
         SendAddonMessage("ScroogeLoot", payload, "RAID")
     end
+
+    -- Update voting frame with this player if possible
+    if addon.ShowCandidates then
+        addon:ShowCandidates({playerName})
+    end
 end
 
 function LootFrame:Start(table)

--- a/core.lua
+++ b/core.lua
@@ -1669,7 +1669,37 @@ function ScroogeLoot:GetResponseColorTable(response)
 end
 
 function ScroogeLoot:GetResponseSort(response)
-	return (self.mldb.responses and self.mldb.responses[response]) and self.mldb.responses[response].sort or db.responses[response].sort
+        return (self.mldb.responses and self.mldb.responses[response]) and self.mldb.responses[response].sort or db.responses[response].sort
+end
+
+--- Populate the VotingFrame's scrolling table with data from PlayerDB
+-- @param candidateList table of player names
+function ScroogeLoot:ShowCandidates(candidateList)
+    local vf = self:GetModule("SLVotingFrame", true)
+    if not vf or not vf.frame or not vf.frame.st then return end
+
+    local rows = {}
+    for _, playerName in ipairs(candidateList) do
+        local p = PlayerDB and PlayerDB[playerName]
+        if p then
+            table.insert(rows, {
+                name = playerName,
+                cols = {
+                    { value = p.name },
+                    { value = p.class },
+                    { value = p.SP },
+                    { value = p.DP },
+                    { value = p.item1 },
+                    { value = p.item2 },
+                    { value = p.item3 }
+                }
+            })
+        else
+            print("No PlayerData for", playerName)
+        end
+    end
+
+    vf.frame.st:SetData(rows)
 end
 
 --#end UI Functions -----------------------------------------------------


### PR DESCRIPTION
## Summary
- implement `ShowCandidates` helper on addon
- call `ShowCandidates` when a roll option is chosen

## Testing
- `luac -p core.lua`
- `luac -p Modules/lootFrame.lua`
- `lua -v`


------
https://chatgpt.com/codex/tasks/task_e_687ca5b7a3988322bf0434a53c1b59b9