### PR TITLE
Add roll messaging with SP/DP adjustments

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -47,21 +47,33 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
         return
     end
 
-    local rollValue = math.random(1, 100)
+    local baseRoll = math.random(1, 100)
+    local sp = data.SP or 0
+    local dp = data.DP or 0
+    local adjustedRoll = baseRoll
+
+    if rollType == "sp" then
+        adjustedRoll = adjustedRoll + sp
+    elseif rollType == "dp" then
+        adjustedRoll = adjustedRoll - dp
+    end
 
     local payload = string.format(
-        "ROLL:%s:%s:%d",
+        "ROLL:%s:%s:%d:%d:%d:%d:%d",
         playerName,
-        rollType:lower(),
-        rollValue
+        rollType,
+        baseRoll,
+        adjustedRoll,
+        sp,
+        dp
     )
+
     if C_ChatInfo and C_ChatInfo.SendAddonMessage then
         C_ChatInfo.SendAddonMessage("ScroogeLoot", payload, "RAID")
     else
         SendAddonMessage("ScroogeLoot", payload, "RAID")
     end
 
-    -- Update voting frame with this player if possible
     if addon.ShowCandidates then
         addon:ShowCandidates({playerName})
     end

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -32,8 +32,8 @@ local function OnAddonMessage(prefix, msg, channel, sender)
     if prefix ~= "ScroogeLoot" then return end
 
     if strsub(msg, 1, 5) == "ROLL:" then
-        local _, name, rollType, rollVal = strsplit(":", msg)
-        SLVotingFrame:AddVotingRowFromPlayer(name, rollType, tonumber(rollVal))
+        local _, name, response, raw, adj, sp, dp = strsplit(":", msg)
+        SLVotingFrame:AddVotingRowFromPlayer(name, response, tonumber(raw), tonumber(adj), tonumber(sp), tonumber(dp))
     end
 end
 
@@ -440,22 +440,22 @@ function SLVotingFrame:BuildST()
 end
 
 -- Add a new row to the voting table using roll information
-function SLVotingFrame:AddVotingRowFromPlayer(name, rollType, rollValue)
-    local data = PlayerDB and PlayerDB[name]
-    if not data then
-        print("No PlayerDB entry for", name)
-        return
-    end
-    local sp = data.SP or 0
-    local dp = data.DP or 0
-    local adjusted = rollValue
-    if rollType == "sp" then
-        adjusted = adjusted + sp
-    elseif rollType == "dp" then
-        adjusted = adjusted - dp
-    end
+function SLVotingFrame:AddVotingRowFromPlayer(name, response, rawRoll, adjRoll, sp, dp)
+    local data = PlayerDB and PlayerDB[name] or {}
     if not self.frame or not self.frame.st then return end
-    local row = { cols = { { value = name }, { value = data.class or "" }, { value = rollType }, { value = rollValue }, { value = sp }, { value = dp }, { value = adjusted } } }
+
+    local row = {
+        cols = {
+            { value = name },
+            { value = data.class or "" },
+            { value = response },
+            { value = rawRoll },
+            { value = sp or 0 },
+            { value = dp or 0 },
+            { value = adjRoll },
+        }
+    }
+
     local st = self.frame.st
     st.data = st.data or {}
     table.insert(st.data, row)


### PR DESCRIPTION
## Summary
- send detailed roll data from loot frame
- parse full roll message in voting frame
- display raw roll, SP/DP values and adjusted roll

## Testing
- `luac -p Modules/lootFrame.lua`
- `luac -p Modules/votingFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_687cafb8053c8322bda2c6b1d95dfb71