### PR TITLE
Implement simple voting table and message handler

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -49,10 +49,16 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
 
     local rollValue = math.random(1, 100)
 
+    local itemLink = items[sessionID] and items[sessionID].link
+    local equipLoc = items[sessionID] and items[sessionID].equipLoc
+    local g1, g2 = addon:GetPlayersGear(itemLink, equipLoc)
+
     local payload = string.format(
-        "ROLL:%s:%s:%d",
+        "ROLL:%s:%s:%s:%s:%d",
         playerName,
         rollType:lower(),
+        g1 or "",
+        g2 or "",
         rollValue
     )
     if C_ChatInfo and C_ChatInfo.SendAddonMessage then

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -28,15 +28,15 @@ local enchanters -- Enchanters drop down menu frame
 local guildRanks = {} -- returned from addon:GetGuildRanks()
 local GuildRankSort, ResponseSort -- Initialize now to avoid errors
 
--- Columns for the simple voting table
 local votingCols = {
-  { name = "Name", width = 100 },
-  { name = "Response", width = 90 },
-  { name = "Item", width = 140 },
-  { name = "Roll", width = 60 },
-  { name = "SP", width = 40 },
-  { name = "DP", width = 40 },
-  { name = "Adjusted", width = 80 },
+    { name = "Name",      width = 100 },
+    { name = "Class",     width = 80  },
+    { name = "Rank",      width = 80  },
+    { name = "Roll Type", width = 90  },
+    { name = "Raw Roll",  width = 70  },
+    { name = "SP",        width = 40  },
+    { name = "DP",        width = 40  },
+    { name = "Adjusted",  width = 70  },
 }
 
 -- Handle incoming addon messages
@@ -505,21 +505,24 @@ end
 function addon:AddVotingRow(data)
     if not addon.VotingTable then return end
 
+    local p = PlayerDB and PlayerDB[data.name] or {}
+
     local row = {
         cols = {
-            { value = data.name, tooltip = data.tooltip },
+            { value = p.name or "?" },
+            { value = p.class or "?" },
+            { value = p.raiderrank and "Raider" or "Non-Raider" },
             { value = data.response },
-            { value = data.item },
             { value = data.roll },
-            { value = data.sp },
-            { value = data.dp },
-            { value = data.adjusted },
+            { value = data.sp or p.SP or 0 },
+            { value = data.dp or p.DP or 0 },
+            { value = data.adjusted, tooltip = data.tooltip or "" },
         }
     }
 
-    local rows = addon.VotingTable:GetData() or {}
-    table.insert(rows, row)
-    addon.VotingTable:SetData(rows)
+    local current = addon.VotingTable:GetData() or {}
+    table.insert(current, row)
+    addon.VotingTable:SetData(current)
 end
 
 function SLVotingFrame:UpdateMoreInfo(row, data)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -32,13 +32,12 @@ local GuildRankSort, ResponseSort -- Initialize now to avoid errors
 -- fields provided by AddVotingRow below. The "Class" column was removed to
 -- simplify the display.
 local votingCols = {
-    { name = "Name",      width = 100 },
-    { name = "Rank",      width = 80  },
-    { name = "Roll Type", width = 90  },
-    { name = "Raw Roll",  width = 70  },
-    { name = "SP",        width = 40  },
-    { name = "DP",        width = 40  },
-    { name = "Adjusted",  width = 70  },
+    { name = "Name",     width = 100 },
+    { name = "Rank",     width = 80  },
+    { name = "Response", width = 100 },
+    { name = "Item 1",   width = 140 },
+    { name = "Item 2",   width = 140 },
+    { name = "Roll",     width = 60  },
 }
 
 -- Handle incoming addon messages
@@ -46,8 +45,14 @@ local function OnAddonMessage(prefix, msg, channel, sender)
     if prefix ~= "ScroogeLoot" then return end
 
     if strsub(msg, 1, 5) == "ROLL:" then
-        local _, name, rollType, rollVal = strsplit(":", msg)
-        SLVotingFrame:AddVotingRowFromPlayer(name, rollType, tonumber(rollVal))
+        local _, name, response, item1, item2, rollVal = strsplit(":", msg)
+        addon:AddVotingRow({
+            name = name,
+            response = response,
+            item1 = item1,
+            item2 = item2,
+            roll = tonumber(rollVal),
+        })
     end
 end
 
@@ -63,17 +68,14 @@ addonMsgFrame:RegisterEvent("CHAT_MSG_ADDON")
 addonMsgFrame:SetScript("OnEvent", function(_, _, prefix, msg, _, sender)
     if prefix ~= "ScroogeLoot" then return end
 
-    local cmd, name, response, item, roll, adj, sp, dp, tooltip = strsplit(":", msg)
+    local cmd, name, response, item1, item2, rollVal = strsplit(":", msg)
     if cmd == "ROLL" then
         addon:AddVotingRow({
             name = name,
             response = response,
-            item = item,
-            roll = tonumber(roll),
-            adjusted = tonumber(adj),
-            sp = tonumber(sp),
-            dp = tonumber(dp),
-            tooltip = tooltip or "",
+            item1 = item1,
+            item2 = item2,
+            roll = tonumber(rollVal),
         })
     end
 end)
@@ -513,13 +515,12 @@ function addon:AddVotingRow(data)
     -- exist yet, fall back to the provided name.
     local row = {
         cols = {
-            { value = p.name or data.name or "?" },
-            { value = p.raiderrank and "Raider" or "Non-Raider" },
-            { value = data.response },
-            { value = data.roll },
-            { value = data.sp or p.SP or 0 },
-            { value = data.dp or p.DP or 0 },
-            { value = data.adjusted, tooltip = data.tooltip or "" },
+            { value = p.name or data.name or "?" },           -- Name
+            { value = p.raiderrank and "Raider" or "Non-Raider" }, -- Rank
+            { value = data.response },                         -- Response
+            { value = data.item1 or "" },                      -- Item 1
+            { value = data.item2 or "" },                      -- Item 2
+            { value = data.roll },                             -- Roll
         }
     }
 

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -28,9 +28,11 @@ local enchanters -- Enchanters drop down menu frame
 local guildRanks = {} -- returned from addon:GetGuildRanks()
 local GuildRankSort, ResponseSort -- Initialize now to avoid errors
 
+-- Columns for the lightweight voting table. These map directly to the
+-- fields provided by AddVotingRow below. The "Class" column was removed to
+-- simplify the display.
 local votingCols = {
     { name = "Name",      width = 100 },
-    { name = "Class",     width = 80  },
     { name = "Rank",      width = 80  },
     { name = "Roll Type", width = 90  },
     { name = "Raw Roll",  width = 70  },
@@ -507,10 +509,11 @@ function addon:AddVotingRow(data)
 
     local p = PlayerDB and PlayerDB[data.name] or {}
 
+    -- Always show the stored player name if available. If the entry doesn't
+    -- exist yet, fall back to the provided name.
     local row = {
         cols = {
-            { value = p.name or "?" },
-            { value = p.class or "?" },
+            { value = p.name or data.name or "?" },
             { value = p.raiderrank and "Raider" or "Non-Raider" },
             { value = data.response },
             { value = data.roll },


### PR DESCRIPTION
## Summary
- expand votingFrame module with ScrollingTable helper
- add new message handler for `ROLL` addon messages
- support adding new rows via `addon:AddVotingRow`
- initialize a simple `VotingTable` when the voting frame is enabled

## Testing
- `luac -p Modules/votingFrame.lua`

------
https://chatgpt.com/codex/tasks/task_e_687cb7f80bd88322a54dba2617223549