### PR TITLE
Update voting frame display and roll logic

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -34,36 +34,36 @@ local function CanEquipItem(name, item) return true end
 -- Send the chosen roll option to the master looter. When executed by the master
 -- it will also generate and broadcast the roll result to the voting frame.
 local function OnRollOptionClick(playerName, responseName, sessionID)
-    addon:SendRoll(responseName, sessionID)
-    if addon.ShowCandidates then
-        addon:ShowCandidates({playerName})
-    end
+	addon:SendRoll(responseName, sessionID)
+	if addon.ShowCandidates then
+	    addon:ShowCandidates({playerName})
+	end
 end
 
 -- Broadcast a roll result to the raid
 function addon:SendRoll(responseType, itemName)
-    local name = UnitName("player")
-    local data = PlayerDB and PlayerDB[name]
-    if not data then
-        print("No PlayerDB for", name)
-        return
-    end
+	local name = UnitName("player")
+	local data = PlayerDB and PlayerDB[name]
+	if not data then
+	    print("No PlayerDB for", name)
+	    return
+	end
 
-    local baseRoll = math.random(1, 100)
-    local sp = data.SP or 0
-    local dp = data.DP or 0
-    local adjusted = baseRoll
+	local baseRoll = math.random(1, 100)
+	local sp = data.SP or 0
+	local dp = data.DP or 0
+	local adjusted = baseRoll
 
-    if responseType == "Scrooge" then
-        adjusted = baseRoll + sp
-    elseif responseType == "Deducktion" or responseType == "Main-Spec" or responseType == "Off-Spec" then
-        adjusted = baseRoll - dp
-    end
+	if responseType == "Scrooge" then
+	    adjusted = baseRoll + sp
+	elseif responseType == "Deducktion" or responseType == "Main-Spec" or responseType == "Off-Spec" then
+	    adjusted = baseRoll - dp
+	end
 
-    local tooltip = string.format("Roll: %d \226\134\146 Adjusted: %d", baseRoll, adjusted)
-    local msg = string.format("ROLL:%s:%s:%d:%d:%d:%d:%s", name, responseType, baseRoll, adjusted, sp, dp, tooltip)
+	local tooltip = string.format("Roll: %d \226\134\146 Adjusted: %d", baseRoll, adjusted)
+	local msg = string.format("ROLL:%s:%s:%d:%d:%d:%d:%s", name, responseType, baseRoll, adjusted, sp, dp, tooltip)
 
-    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
+	if C_ChatInfo and C_ChatInfo.SendAddonMessage then
         C_ChatInfo.SendAddonMessage("ScroogeLoot", msg, "RAID")
     else
         SendAddonMessage("ScroogeLoot", msg, "RAID")
@@ -234,17 +234,17 @@ function LootFrame:Update()
 end
 
 function LootFrame:OnRoll(entry, button)
-       addon:Debug("LootFrame:OnRoll", entry, button, "Response:", addon:GetResponseText(button))
-       local index = entries[entry].realID
+	addon:Debug("LootFrame:OnRoll", entry, button, "Response:", addon:GetResponseText(button))
+	local index = entries[entry].realID
 
-       if button ~= "PASS" then
-               local responseName = addon:GetButtonText(button)
-               OnRollOptionClick(UnitName("player"), responseName, items[index].session)
-       end
+	if button ~= "PASS" then
+		local responseName = addon:GetButtonText(button)
+		OnRollOptionClick(UnitName("player"), responseName, items[index].session)
+		end
 
-       numRolled = numRolled + 1
-       items[index].rolled = true
-       self:Update()
+	numRolled = numRolled + 1
+	items[index].rolled = true
+	self:Update()
 end
 
 function LootFrame:GetFrame()

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -9,6 +9,7 @@ local SLVotingFrame = addon:NewModule("SLVotingFrame", "AceComm-3.0", "AceTimer-
 local LibDialog = LibStub("LibDialog-1.0")
 local L = LibStub("AceLocale-3.0"):GetLocale("ScroogeLoot")
 local Deflate = LibStub("LibDeflate")
+local ST = LibStub("ScrollingTable")
 
 local ROW_HEIGHT = 20;
 local NUM_ROWS = 15;
@@ -27,13 +28,32 @@ local enchanters -- Enchanters drop down menu frame
 local guildRanks = {} -- returned from addon:GetGuildRanks()
 local GuildRankSort, ResponseSort -- Initialize now to avoid errors
 
+-- Columns for the lightweight voting table
+local votingCols = {
+    { name = "Name", width = 100 },
+    { name = "Rank", width = 60 },
+    { name = "Response", width = 100 },
+    { name = "Roll", width = 60 },
+    { name = "SP", width = 40 },
+    { name = "DP", width = 40 },
+    { name = "Adjusted", width = 80 },
+}
+
 -- Handle incoming addon messages
 local function OnAddonMessage(prefix, msg, channel, sender)
     if prefix ~= "ScroogeLoot" then return end
 
-    if strsub(msg, 1, 5) == "ROLL:" then
-        local _, name, rollType, rollVal = strsplit(":", msg)
-        SLVotingFrame:AddVotingRowFromPlayer(name, rollType, tonumber(rollVal))
+    local cmd, name, response, roll, adjusted, sp, dp, tooltip = strsplit(":", msg)
+    if cmd == "ROLL" then
+        addon:AddVotingRow({
+            name = name,
+            response = response,
+            roll = tonumber(roll),
+            adjusted = tonumber(adjusted),
+            sp = tonumber(sp),
+            dp = tonumber(dp),
+            tooltip = tooltip,
+        })
     end
 end
 
@@ -136,21 +156,37 @@ function SLVotingFrame:OnInitialize()
 end
 
 function SLVotingFrame:OnEnable()
-	self:RegisterComm("ScroogeLoot")
-	db = addon:Getdb()
-	active = true
-	moreInfo = db.modules["SLVotingFrame"].moreInfo
-	self.frame = self:GetFrame()
+        self:RegisterComm("ScroogeLoot")
+        db = addon:Getdb()
+        active = true
+        moreInfo = db.modules["SLVotingFrame"].moreInfo
+        self.frame = self:GetFrame()
+
+        -- hide the original scrolling table
+        if self.frame.st and self.frame.st.frame then
+            self.frame.st.frame:Hide()
+        end
+
+        if not addon.VotingTable then
+            addon.VotingTable = ST:CreateST(votingCols, NUM_ROWS, ROW_HEIGHT, nil, self.frame)
+            addon.VotingTable.frame:SetPoint("TOPLEFT", self.frame, "TOPLEFT", 15, -20)
+        else
+            addon.VotingTable.frame:SetParent(self.frame)
+            addon.VotingTable.frame:Show()
+        end
 end
 
 function SLVotingFrame:OnDisable() -- We never really call this
-	self:Hide()
-	self.frame:SetParent(nil)
-	self.frame = nil
-	wipe(lootTable)
-	active = false
-	session = 1
-	self:UnregisterAllComm()
+        self:Hide()
+        if addon.VotingTable then
+            addon.VotingTable.frame:Hide()
+        end
+        self.frame:SetParent(nil)
+        self.frame = nil
+        wipe(lootTable)
+        active = false
+        session = 1
+        self:UnregisterAllComm()
 end
 
 function SLVotingFrame:Hide()
@@ -455,6 +491,29 @@ end
 function SLVotingFrame:BuildST()
         -- Start with an empty table; rows will be added dynamically
         self.frame.st:SetData({})
+end
+
+-- Simple helper used by the lightweight voting table
+function addon:AddVotingRow(data)
+    local p = PlayerDB and PlayerDB[data.name] or {}
+
+    local row = {
+        cols = {
+            { value = p.name or data.name },
+            { value = p.raiderrank and "Y" or "" },
+            { value = data.response },
+            { value = data.roll },
+            { value = data.sp or 0 },
+            { value = data.dp or 0 },
+            { value = data.adjusted, tooltip = data.tooltip or "" },
+        }
+    }
+
+    if addon.VotingTable then
+        local current = addon.VotingTable:GetData() or {}
+        table.insert(current, row)
+        addon.VotingTable:SetData(current)
+    end
 end
 
 -- Add a new row to the voting table using roll information

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -43,17 +43,17 @@ local votingCols = {
 local function OnAddonMessage(prefix, msg, channel, sender)
     if prefix ~= "ScroogeLoot" then return end
 
-    local cmd, name, response, roll, adjusted, sp, dp, tooltip = strsplit(":", msg)
-    if cmd == "ROLL" then
-        addon:AddVotingRow({
-            name = name,
-            response = response,
-            roll = tonumber(roll),
-            adjusted = tonumber(adjusted),
-            sp = tonumber(sp),
-            dp = tonumber(dp),
-            tooltip = tooltip,
-        })
+	local cmd, name, response, roll, adjusted, sp, dp, tooltip = strsplit(":", msg)
+	if cmd == "ROLL" then
+		addon:AddVotingRow({
+		name = name,
+		response = response,
+		roll = tonumber(roll),
+		adjusted = tonumber(adjusted),
+		sp = tonumber(sp),
+		dp = tonumber(dp),
+		tooltip = tooltip,
+		})
     end
 end
 
@@ -156,24 +156,24 @@ function SLVotingFrame:OnInitialize()
 end
 
 function SLVotingFrame:OnEnable()
-        self:RegisterComm("ScroogeLoot")
-        db = addon:Getdb()
-        active = true
-        moreInfo = db.modules["SLVotingFrame"].moreInfo
-        self.frame = self:GetFrame()
+	self:RegisterComm("ScroogeLoot")
+	db = addon:Getdb()
+	active = true
+	moreInfo = db.modules["SLVotingFrame"].moreInfo
+	self.frame = self:GetFrame()
 
-        -- hide the original scrolling table
-        if self.frame.st and self.frame.st.frame then
-            self.frame.st.frame:Hide()
-        end
+	-- hide the original scrolling table
+	if self.frame.st and self.frame.st.frame then
+	    self.frame.st.frame:Hide()
+	end
 
-        if not addon.VotingTable then
-            addon.VotingTable = ST:CreateST(votingCols, NUM_ROWS, ROW_HEIGHT, nil, self.frame)
-            addon.VotingTable.frame:SetPoint("TOPLEFT", self.frame, "TOPLEFT", 15, -20)
-        else
-            addon.VotingTable.frame:SetParent(self.frame)
-            addon.VotingTable.frame:Show()
-        end
+	if not addon.VotingTable then
+	    addon.VotingTable = ST:CreateST(votingCols, NUM_ROWS, ROW_HEIGHT, nil, self.frame)
+	    addon.VotingTable.frame:SetPoint("TOPLEFT", self.frame, "TOPLEFT", 15, -20)
+	else
+	    addon.VotingTable.frame:SetParent(self.frame)
+	    addon.VotingTable.frame:Show()
+	end
 end
 
 function SLVotingFrame:OnDisable() -- We never really call this
@@ -495,35 +495,35 @@ end
 
 -- Simple helper used by the lightweight voting table
 function addon:AddVotingRow(data)
-    local p = PlayerDB and PlayerDB[data.name] or {}
+	local p = PlayerDB and PlayerDB[data.name] or {}
 
-    local row = {
-        cols = {
-            { value = p.name or data.name },
-            { value = p.raiderrank and "Y" or "" },
-            { value = data.response },
-            { value = data.roll },
-            { value = data.sp or 0 },
-            { value = data.dp or 0 },
-            { value = data.adjusted, tooltip = data.tooltip or "" },
-        }
-    }
+	local row = {
+	    cols = {
+	        { value = p.name or data.name },
+		{ value = p.raiderrank and "Y" or "" },
+		{ value = data.response },
+		{ value = data.roll },
+		{ value = data.sp or 0 },
+		{ value = data.dp or 0 },
+		{ value = data.adjusted, tooltip = data.tooltip or "" },
+		}
+		}
 
-    if addon.VotingTable then
-        local current = addon.VotingTable:GetData() or {}
-        table.insert(current, row)
-        addon.VotingTable:SetData(current)
-    end
+		if addon.VotingTable then
+		local current = addon.VotingTable:GetData() or {}
+		table.insert(current, row)
+		addon.VotingTable:SetData(current)
+		end
 end
 
 -- Add a new row to the voting table using roll information
 function SLVotingFrame:AddVotingRowFromPlayer(name, rollType, rollValue)
-    local data = PlayerDB and PlayerDB[name]
-    if not data then
-        print("No PlayerDB entry for", name)
-        return
-    end
-    local sp = data.SP or 0
+	local data = PlayerDB and PlayerDB[name]
+	if not data then
+	    print("No PlayerDB entry for", name)
+	    return
+	end
+	local sp = data.SP or 0
     local dp = data.DP or 0
     local baseRoll = math.random(1, 100)
     local adjusted = baseRoll


### PR DESCRIPTION
## Summary
- show stored player names in the voting frame
- display `raiderrank` value in the Rank column
- roll between 1-100 when a response is processed and apply SP/DP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d0589af0c83229e12018271c16118