### PR TITLE
Fix roll session and tooltip

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -64,6 +64,11 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
         SendAddonMessage("ScroogeLoot", payload, "RAID")
     end
 
+    -- Inform the master looter about this roll choice so it can be tied to the
+    -- proper session. The sessionID refers to the item currently displayed in
+    -- the loot frame.
+    addon:SendCommand("group", "roll_choice", {sessionID, playerName, rollType})
+
     -- Update voting frame with this player if possible
     if addon.ShowCandidates then
         addon:ShowCandidates({playerName})

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1080,19 +1080,30 @@ function SLVotingFrame.SetCellNote(rowFrame, frame, data, cols, row, realrow, co
 	frame.noteBtn = f
 end
 
-function SLVotingFrame.SetCellRoll(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
-       local name = data[realrow].name
-       local info = lootTable[session].candidates[name].rollInfo or {}
-       frame.text:SetText(lootTable[session].candidates[name].roll)
-       frame:SetScript("OnEnter", function()
-               addon:CreateTooltip(
-                       "Base: "..tostring(info.base),
-                       info.reason == "+SP" and "+SP: "..tostring(info.SP) or info.reason == "-DP" and "-DP: "..tostring(info.DP) or nil,
-                       "Final: "..tostring(info.final)
-               )
-       end)
-       frame:SetScript("OnLeave", addon.HideTooltip)
-       data[realrow].cols[column].value = lootTable[session].candidates[name].roll
+function SLVotingFrame.SetCellRoll(_, frame, data, cols, row, realrow, column)
+    local roll = data[realrow].roll or ""
+    frame.text:SetText(roll)
+    local info = data[realrow].rollInfo
+
+    if info then
+        local breakdown = "Roll " .. (info.base or "?")
+        if info.SP and info.SP > 0 then
+            breakdown = breakdown .. " + " .. info.SP .. " SP"
+        elseif info.DP and info.DP > 0 then
+            breakdown = breakdown .. " - " .. info.DP .. " DP"
+        end
+        breakdown = breakdown .. " = " .. (info.final or "?")
+        frame:SetScript("OnEnter", function()
+            GameTooltip:SetOwner(frame, "ANCHOR_RIGHT")
+            GameTooltip:SetText(breakdown)
+            GameTooltip:Show()
+        end)
+        frame:SetScript("OnLeave", function() GameTooltip:Hide() end)
+    else
+        frame:SetScript("OnEnter", nil)
+        frame:SetScript("OnLeave", nil)
+    end
+    data[realrow].cols[column].value = roll
 end
 
 function SLVotingFrame.filterFunc(table, row)


### PR DESCRIPTION
## Summary
- ensure rolls are associated with the correct session
- improve roll tooltip display

## Testing
- `lua` not installed, no tests run

------
https://chatgpt.com/codex/tasks/task_e_687ea32fbe40832280b0b16f4c5a93f3