### PR TITLE
Fix roll processing for loot

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -32,42 +32,7 @@ local function PlayerGotItem(p, item) return false end
 local function CanEquipItem(name, item) return true end
 
 local function OnRollOptionClick(playerName, rollType, sessionID)
-    local db = PlayerDB and PlayerDB[playerName]
-    if not db then
-        local _, class = UnitClass(playerName)
-        if RegisterPlayer then
-            RegisterPlayer(playerName, class)
-        end
-        db = PlayerDB and PlayerDB[playerName]
-    end
-    if not db then
-        print("Player not found in PlayerDB:", playerName)
-        return
-    end
-
-    local baseRoll = math.random(1, 100)
-    local sp = db.SP or 0
-    local dp = db.DP or 0
-
-    local payload = string.format(
-        "ROLL:%s:%s:%d:%d:%d",
-        playerName,
-        rollType,
-        baseRoll,
-        sp,
-        dp
-    )
-
-    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
-        C_ChatInfo.SendAddonMessage("ScroogeLoot", payload, "RAID")
-    else
-        SendAddonMessage("ScroogeLoot", payload, "RAID")
-    end
-
-    -- Update voting frame with this player if possible
-    if addon.ShowCandidates then
-        addon:ShowCandidates({playerName})
-    end
+    addon:SendCommand("group", "roll_choice", {sessionID, playerName, rollType})
 end
 
 function LootFrame:Start(table)

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -93,40 +93,6 @@ local function UpdateVotingRow(playerName)
     end
 end
 
--- Master looter only: handle an incoming roll choice and update the table
-local function HandleRollChoice(sessionID, playerName, rollType)
-    local playerData = PlayerDB and PlayerDB[playerName]
-    if not playerData then
-        local _, class = UnitClass(playerName)
-        if RegisterPlayer then
-            RegisterPlayer(playerName, class)
-        end
-        playerData = PlayerDB and PlayerDB[playerName]
-    end
-    if not playerData or not sessionID then return end
-
-    local baseRoll = math.random(1, 100)
-    local modifiedRoll = baseRoll
-
-    if rollType == "SP" then
-        modifiedRoll = baseRoll + (playerData.SP or 0)
-    elseif rollType == "DP" then
-        modifiedRoll = baseRoll - (playerData.DP or 0)
-    end
-
-    SLVotingFrame:SetCandidateData(sessionID, playerName, "roll", modifiedRoll)
-    SLVotingFrame:SetCandidateData(sessionID, playerName, "rollInfo", {
-        base = baseRoll,
-        final = modifiedRoll,
-        SP = playerData.SP,
-        DP = playerData.DP,
-    })
-    if SLVotingFrame.frame and SLVotingFrame.frame.st then
-        SLVotingFrame.frame.st:Refresh()
-    end
-    UpdateVotingRow(playerName)
-    SLVotingFrame:Update()
-end
 
 function SLVotingFrame:OnInitialize()
         self.scrollCols = {
@@ -248,7 +214,7 @@ function SLVotingFrame:OnCommReceived(prefix, serializedMsg, distri, sender)
 
                        elseif command == "roll_choice" and addon.isMasterLooter then
                                local ses, name, rType = unpack(data)
-                               HandleRollChoice(ses, name, rType)
+                               addon:HandleRollChoice(tonumber(ses), name, rType)
 
                        elseif command == "lootAck" then
 				local name = unpack(data)
@@ -1080,19 +1046,29 @@ function SLVotingFrame.SetCellNote(rowFrame, frame, data, cols, row, realrow, co
 	frame.noteBtn = f
 end
 
-function SLVotingFrame.SetCellRoll(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
-       local name = data[realrow].name
-       local info = lootTable[session].candidates[name].rollInfo or {}
-       frame.text:SetText(lootTable[session].candidates[name].roll)
-       frame:SetScript("OnEnter", function()
-               addon:CreateTooltip(
-                       "Base: "..tostring(info.base),
-                       info.reason == "+SP" and "+SP: "..tostring(info.SP) or info.reason == "-DP" and "-DP: "..tostring(info.DP) or nil,
-                       "Final: "..tostring(info.final)
-               )
-       end)
-       frame:SetScript("OnLeave", addon.HideTooltip)
-       data[realrow].cols[column].value = lootTable[session].candidates[name].roll
+function SLVotingFrame.SetCellRoll(_, frame, data, _, _, realrow)
+       local roll = data[realrow].roll or ""
+       frame.text:SetText(roll)
+
+       local info = data[realrow].rollInfo
+       if info then
+               local t = "Roll " .. (info.base or "?")
+               if info.SP then
+                       t = t .. " + " .. info.SP .. " SP"
+               elseif info.DP then
+                       t = t .. " - " .. info.DP .. " DP"
+               end
+               t = t .. " = " .. info.final
+               frame:SetScript("OnEnter", function()
+                       GameTooltip:SetOwner(frame, "ANCHOR_RIGHT")
+                       GameTooltip:SetText(t)
+                       GameTooltip:Show()
+               end)
+               frame:SetScript("OnLeave", GameTooltip_Hide)
+       else
+               frame:SetScript("OnEnter", nil)
+               frame:SetScript("OnLeave", nil)
+       end
 end
 
 function SLVotingFrame.filterFunc(table, row)

--- a/core.lua
+++ b/core.lua
@@ -773,8 +773,8 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 			elseif command == "playerInfoRequest" then
 				self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
 
-			elseif command == "playerData" then
-				-- Update local PlayerData from the master looter
+                        elseif command == "playerData" then
+                                -- Update local PlayerData from the master looter
                                 if not self.isMasterLooter then
                                         local incomingData = unpack(data)
                                         self.PlayerData = incomingData
@@ -785,8 +785,11 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
                                                 self.playerDB.global.playerData = incomingData
                                         end
                                 end
-			elseif command == "message" then
-				self:Print(unpack(data))
+                        elseif command == "roll_choice" then
+                                local ses, name, rType = unpack(data)
+                                self:HandleRollChoice(tonumber(ses), name, rType)
+                        elseif command == "message" then
+                                self:Print(unpack(data))
 
 			elseif command == "session_end" and self.enabled then
 				if self:UnitIsUnit(sender, self.masterLooter) then

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -806,7 +806,36 @@ function ScroogeLootML:SendWhisperHelp(target)
 		SendChatMessage(msg, "WHISPER", nil, target)
 	end
 	SendChatMessage(L["whisper_guide2"], "WHISPER", nil, target)
-	addon:Print(format(L["Sent whisper help to 'player'"], target))
+        addon:Print(format(L["Sent whisper help to 'player'"], target))
+end
+
+-- Process a player's roll choice and update the voting frame
+function addon:HandleRollChoice(sessionID, playerName, rollType)
+    if not addon.isMasterLooter then return end
+    if not sessionID or not playerName or not rollType then return end
+
+    local pdata = PlayerDB and PlayerDB[playerName]
+    if not pdata then return end
+
+    local base = math.random(1, 100)
+    local final = base
+    local info = { base = base, final = base }
+
+    if rollType == "Scrooge" then
+        final = base + (pdata.SP or 0)
+        info.SP = pdata.SP or 0
+    elseif rollType == "Deducktion" or rollType == "Main-Spec" or rollType == "Off-Spec" then
+        final = base - (pdata.DP or 0)
+        info.DP = pdata.DP or 0
+    end
+
+    info.final = final
+
+    SLVotingFrame:SetCandidateData(sessionID, playerName, "response", rollType)
+    SLVotingFrame:SetCandidateData(sessionID, playerName, "roll", final)
+    SLVotingFrame:SetCandidateData(sessionID, playerName, "rollInfo", info)
+
+    SLVotingFrame:Update()
 end
 
 --------ML Popups ------------------


### PR DESCRIPTION
## Summary
- implement `addon:HandleRollChoice` to calculate modified rolls
- dispatch `roll_choice` messages in `core.lua`
- send `roll_choice` when clicking loot buttons
- connect voting frame tooltips to roll info

## Testing
- `luac -p` on all Lua files

------
https://chatgpt.com/codex/tasks/task_e_687f5adcd078832284e83a6fc2611e46