### PR TITLE
Implement roll choice handling

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -32,37 +32,7 @@ local function PlayerGotItem(p, item) return false end
 local function CanEquipItem(name, item) return true end
 
 local function OnRollOptionClick(playerName, rollType, sessionID)
-    local db = PlayerDB and PlayerDB[playerName]
-    if not db then
-        local _, class = UnitClass(playerName)
-        if RegisterPlayer then
-            RegisterPlayer(playerName, class)
-        end
-        db = PlayerDB and PlayerDB[playerName]
-    end
-    if not db then
-        print("Player not found in PlayerDB:", playerName)
-        return
-    end
-
-    local baseRoll = math.random(1, 100)
-    local sp = db.SP or 0
-    local dp = db.DP or 0
-
-    local payload = string.format(
-        "ROLL:%s:%s:%d:%d:%d",
-        playerName,
-        rollType,
-        baseRoll,
-        sp,
-        dp
-    )
-
-    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
-        C_ChatInfo.SendAddonMessage("ScroogeLoot", payload, "RAID")
-    else
-        SendAddonMessage("ScroogeLoot", payload, "RAID")
-    end
+    addon:SendCommand("group", "roll_choice", { sessionID, playerName, rollType })
 
     -- Update voting frame with this player if possible
     if addon.ShowCandidates then

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -1080,19 +1080,29 @@ function SLVotingFrame.SetCellNote(rowFrame, frame, data, cols, row, realrow, co
 	frame.noteBtn = f
 end
 
-function SLVotingFrame.SetCellRoll(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
-       local name = data[realrow].name
-       local info = lootTable[session].candidates[name].rollInfo or {}
-       frame.text:SetText(lootTable[session].candidates[name].roll)
-       frame:SetScript("OnEnter", function()
-               addon:CreateTooltip(
-                       "Base: "..tostring(info.base),
-                       info.reason == "+SP" and "+SP: "..tostring(info.SP) or info.reason == "-DP" and "-DP: "..tostring(info.DP) or nil,
-                       "Final: "..tostring(info.final)
-               )
-       end)
-       frame:SetScript("OnLeave", addon.HideTooltip)
-       data[realrow].cols[column].value = lootTable[session].candidates[name].roll
+function SLVotingFrame.SetCellRoll(_, frame, data, _, _, realrow)
+    local roll = data[realrow].roll or ""
+    frame.text:SetText(roll)
+
+    local info = data[realrow].rollInfo
+    if info then
+        local t = "Roll " .. (info.base or "?")
+        if info.SP then
+            t = t .. " + " .. info.SP .. " SP"
+        elseif info.DP then
+            t = t .. " - " .. info.DP .. " DP"
+        end
+        t = t .. " = " .. (info.final or "?")
+        frame:SetScript("OnEnter", function()
+            GameTooltip:SetOwner(frame, "ANCHOR_RIGHT")
+            GameTooltip:SetText(t)
+            GameTooltip:Show()
+        end)
+        frame:SetScript("OnLeave", GameTooltip_Hide)
+    else
+        frame:SetScript("OnEnter", nil)
+        frame:SetScript("OnLeave", nil)
+    end
 end
 
 function SLVotingFrame.filterFunc(table, row)

--- a/core.lua
+++ b/core.lua
@@ -770,8 +770,14 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 				self:CallModule("lootframe")
 				self:GetActiveModule("lootframe"):ReRoll(unpack(data))
 
-			elseif command == "playerInfoRequest" then
-				self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
+                        elseif command == "playerInfoRequest" then
+                                self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
+
+                        elseif command == "roll_choice" then
+                                local sessionID, playerName, rollType = unpack(data)
+                                if self.HandleRollChoice then
+                                        self:HandleRollChoice(tonumber(sessionID), playerName, rollType)
+                                end
 
 			elseif command == "playerData" then
 				-- Update local PlayerData from the master looter

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -809,6 +809,35 @@ function ScroogeLootML:SendWhisperHelp(target)
 	addon:Print(format(L["Sent whisper help to 'player'"], target))
 end
 
+function addon:HandleRollChoice(sessionID, playerName, rollType)
+    if not sessionID or not playerName or not rollType then return end
+
+    local pdata = PlayerDB[playerName]
+    if not pdata then return end
+
+    local baseRoll = math.random(1, 100)
+    local finalRoll = baseRoll
+    local rollInfo = { base = baseRoll }
+
+    if rollType == "Scrooge" then
+        rollInfo.SP = pdata.SP or 0
+        finalRoll = finalRoll + rollInfo.SP
+    elseif rollType == "Deducktion" or rollType == "Main-Spec" or rollType == "Off-Spec" then
+        rollInfo.DP = pdata.DP or 0
+        finalRoll = finalRoll - rollInfo.DP
+    end
+
+    rollInfo.final = finalRoll
+
+    local vf = addon:GetModule("SLVotingFrame", true)
+    if vf and vf.SetCandidateData then
+        vf:SetCandidateData(sessionID, playerName, "response", rollType)
+        vf:SetCandidateData(sessionID, playerName, "roll", finalRoll)
+        vf:SetCandidateData(sessionID, playerName, "rollInfo", rollInfo)
+        vf:Update()
+    end
+end
+
 --------ML Popups ------------------
 LibDialog:Register("SLLOOTCOUNCIL_CONFIRM_ABORT", {
 	text = L["Are you sure you want to abort?"],


### PR DESCRIPTION
## Summary
- send roll_choice messages when selecting loot roll options
- display detailed roll breakdown in voting tooltip
- route roll_choice command through comm handler
- compute adjusted roll values in new `HandleRollChoice`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fadb348208322a2b093cdd509db7d