### PR TITLE
Add close button to player management frame

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -46,6 +46,11 @@ function SLPlayerManagementFrame:GetFrame()
     local f = addon:CreateFrame("SLPlayerManagementFrame", "playermanagement", L["Player Management"], 900, 350)
     self:CreateUI(f.content)
     f:SetWidth(f.content.st.frame:GetWidth()+20)
+
+    local closeBtn = addon:CreateButton(L["Close"], f.content)
+    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -10, -10)
+    closeBtn:SetScript("OnClick", function() self:Hide() end)
+    f.closeBtn = closeBtn
     return f
 end
 


### PR DESCRIPTION
## Summary
- allow closing the Player Management frame

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb14efd888322bb78dafeced5f568