### PR TITLE
Fix title placement in player management frame

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -59,9 +59,7 @@ function SLPlayerManagementFrame:GetFrame()
     content.resetBtn:ClearAllPoints()
     content.resetBtn:SetPoint("RIGHT", content.saveBtn, "LEFT", -10, 0)
 
-    -- Move the title slightly above the frame
-    f.title:ClearAllPoints()
-    f.title:SetPoint("BOTTOM", f, "TOP", 0, 5)
+    -- Title is part of the frame; keep default positioning
 
     return f
 end


### PR DESCRIPTION
## Summary
- keep the player management frame title inside the frame instead of repositioning it above

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fc82ca83c83229af3f3dd0ca83742