### PR TITLE
Integrate PlayerDB data into rolls

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -32,42 +32,7 @@ local function PlayerGotItem(p, item) return false end
 local function CanEquipItem(name, item) return true end
 
 local function OnRollOptionClick(playerName, rollType, sessionID)
-    local db = PlayerDB and PlayerDB[playerName]
-    if not db then
-        local _, class = UnitClass(playerName)
-        if RegisterPlayer then
-            RegisterPlayer(playerName, class)
-        end
-        db = PlayerDB and PlayerDB[playerName]
-    end
-    if not db then
-        print("Player not found in PlayerDB:", playerName)
-        return
-    end
-
-    local baseRoll = math.random(1, 100)
-    local sp = db.SP or 0
-    local dp = db.DP or 0
-
-    local payload = string.format(
-        "ROLL:%s:%s:%d:%d:%d",
-        playerName,
-        rollType,
-        baseRoll,
-        sp,
-        dp
-    )
-
-    if C_ChatInfo and C_ChatInfo.SendAddonMessage then
-        C_ChatInfo.SendAddonMessage("ScroogeLoot", payload, "RAID")
-    else
-        SendAddonMessage("ScroogeLoot", payload, "RAID")
-    end
-
-    -- Update voting frame with this player if possible
-    if addon.ShowCandidates then
-        addon:ShowCandidates({playerName})
-    end
+    addon:SendCommand("group", "roll_choice", { sessionID, playerName, rollType })
 end
 
 function LootFrame:Start(table)


### PR DESCRIPTION
## Summary
- use SendCommand in loot frame to send roll choice
- build voting rows from PlayerDB when no loot table
- show roll breakdown tooltip using GameTooltip
- add HandleRollChoice helper and react to roll_choice in ML comms

## Testing
- `luac -p` on project files


------
https://chatgpt.com/codex/tasks/task_e_68809479ed7883228e3633ee745e5e1f