### PR TITLE
Fix session mismatch for voting rolls

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -50,7 +50,8 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
     local dp = db.DP or 0
 
     local payload = string.format(
-        "ROLL:%s:%s:%d:%d:%d",
+        "ROLL:%d:%s:%s:%d:%d:%d",
+        sessionID,
         playerName,
         rollType,
         baseRoll,

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -32,7 +32,8 @@ local function OnAddonMessage(prefix, msg, channel, sender)
     if prefix ~= "ScroogeLoot" then return end
 
     if strsub(msg, 1, 5) == "ROLL:" then
-        local _, name, rollType, base, sp, dp = strsplit(":", msg)
+        local _, ses, name, rollType, base, sp, dp = strsplit(":", msg)
+        ses = tonumber(ses)
         base = tonumber(base)
         sp = tonumber(sp)
         dp = tonumber(dp)
@@ -43,9 +44,11 @@ local function OnAddonMessage(prefix, msg, channel, sender)
             final = base - dp
         end
         if SLVotingFrame then
-            SLVotingFrame:SetCandidateData(nil, name, "response", rollType)
-            SLVotingFrame:SetCandidateData(nil, name, "roll", final)
-            SLVotingFrame:Update()
+            SLVotingFrame:SetCandidateData(ses, name, "response", rollType)
+            SLVotingFrame:SetCandidateData(ses, name, "roll", final)
+            if ses == session then
+                SLVotingFrame:Update()
+            end
         end
     end
 end


### PR DESCRIPTION
## Summary
- ensure roll messages include the session id
- update voting frame to apply rolls to the correct session

## Testing
- `luac -p Modules/lootFrame.lua`
- `luac -p Modules/votingFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_6880fdcbe58083228989b2340999d5c4