### PR TITLE
Fix roll assignment per session

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -79,7 +79,8 @@ local function OnRollOptionClick(playerName, rollType, sessionID)
     local dp = db.DP or 0
 
     local payload = string.format(
-        "ROLL:%s:%s:%d:%d:%d",
+        "ROLL:%d:%s:%s:%d:%d:%d",
+        sessionID,
         playerName,
         rollType,
         baseRoll,

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -32,7 +32,8 @@ local function OnAddonMessage(prefix, msg, channel, sender)
     if prefix ~= "ScroogeLoot" then return end
 
     if strsub(msg, 1, 5) == "ROLL:" then
-        local _, name, rollType, base, sp, dp = strsplit(":", msg)
+        local _, ses, name, rollType, base, sp, dp = strsplit(":", msg)
+        ses = tonumber(ses)
         base = tonumber(base)
         sp = tonumber(sp)
         dp = tonumber(dp)
@@ -43,8 +44,8 @@ local function OnAddonMessage(prefix, msg, channel, sender)
             final = base - dp
         end
         if SLVotingFrame then
-            SLVotingFrame:SetCandidateData(nil, name, "response", rollType)
-            SLVotingFrame:SetCandidateData(nil, name, "roll", final)
+            SLVotingFrame:SetCandidateData(ses, name, "response", rollType)
+            SLVotingFrame:SetCandidateData(ses, name, "roll", final)
             SLVotingFrame:Update()
         end
     end

--- a/core.lua
+++ b/core.lua
@@ -289,8 +289,9 @@ function ScroogeLoot:OnEnable()
         rollFrame:RegisterEvent("CHAT_MSG_ADDON")
         rollFrame:SetScript("OnEvent", function(_, event, prefix, msg, _, sender)
                 if prefix == "ScroogeLoot" then
-                        local cmd, name, rType, base, sp, dp = strsplit(":", msg)
+                        local cmd, ses, name, rType, base, sp, dp = strsplit(":", msg)
                         if cmd == "ROLL" then
+                                ses = tonumber(ses)
                                 local final = tonumber(base)
                                 if rType == "Scrooge" then
                                         final = final + tonumber(sp)
@@ -299,8 +300,8 @@ function ScroogeLoot:OnEnable()
                                 end
                                 local vf = self:GetModule("SLVotingFrame", true)
                                 if vf then
-                                        vf:SetCandidateData(nil, name, "response", rType)
-                                        vf:SetCandidateData(nil, name, "roll", final)
+                                        vf:SetCandidateData(ses, name, "response", rType)
+                                        vf:SetCandidateData(ses, name, "roll", final)
                                         vf:Update()
                                 end
                         end


### PR DESCRIPTION
## Summary
- include the item session in the roll broadcast
- apply incoming rolls to the correct session and player only

## Testing
- `lua Libs/lib-st/LibStub/tests/test.lua` *(fails: attempt to call a nil value)*
- `lua -v`

------
https://chatgpt.com/codex/tasks/task_e_6887b41043f88322808613378054b8f3