### PR TITLE
Add Attendance Check button

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -147,6 +147,7 @@ L["Enter your note:"] = true
 L["Everyone have voted"] = true
 L["Filter"] = true
 L["Following winners was registered:"] = true
+L["Attendance Check"] = true
 L["Free"] = true
 L["From:"] = true
 L["g1"] = true

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -801,6 +801,18 @@ function SLVotingFrame:GetFrame()
 	--b4:SetNormalTexture("Interface\\Icons\\INV_Enchant_Disenchant")
 --	b4:Hide() -- hidden by default
 	f.disenchant = b4
+        -- Attendance Check button
+        local b5 = addon:CreateButton(L["Attendance Check"], f.content)
+        b5:SetPoint("RIGHT", b4, "LEFT", -10, 0)
+        b5:SetScript("OnClick", function()
+                local pm = addon:GetModule("SLPlayerManagementFrame", true)
+                if pm and pm.Show then
+                        pm:Show()
+                else
+                        addon:Print("Attendance frame not available")
+                end
+        end)
+        f.attendance = b5
 
 	-- Number of votes
 	local rf = CreateFrame("Frame", nil, f.content)


### PR DESCRIPTION
## Summary
- add a new "Attendance Check" button next to Disenchant in the voting frame
- wire the button to open the Player Management frame when clicked
- localize the new string

## Testing
- `luac -p Modules/votingFrame.lua`
- `luac -p Locale/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_6887bfed9bc88322b5d1c81d706473d0