### PR TITLE
Improve roll breakdown tooltip

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -58,6 +58,19 @@ local function OnAddonMessage(prefix, msg, channel, sender)
             SLVotingFrame:SetCandidateData(ses, name, "response", response)
             SLVotingFrame:SetCandidateData(ses, name, "responseName", rollType)
             SLVotingFrame:SetCandidateData(ses, name, "roll", final)
+            local reason
+            if rollType == "Scrooge" then
+                reason = "+SP"
+            elseif rollType == "Deducktion" or rollType == "Main-Spec" or rollType == "Off-Spec" then
+                reason = "-DP"
+            end
+            SLVotingFrame:SetCandidateData(ses, name, "rollInfo", {
+                base = base,
+                SP = sp,
+                DP = dp,
+                final = final,
+                reason = reason,
+            })
             SLVotingFrame:Update()
         end
     end

--- a/core.lua
+++ b/core.lua
@@ -301,7 +301,21 @@ function ScroogeLoot:OnEnable()
                                 local vf = self:GetModule("SLVotingFrame", true)
                                 if vf then
                                         vf:SetCandidateData(ses, name, "response", rType)
+                                        vf:SetCandidateData(ses, name, "responseName", rType)
                                         vf:SetCandidateData(ses, name, "roll", final)
+                                        local reason
+                                        if rType == "Scrooge" then
+                                                reason = "+SP"
+                                        elseif rType == "Deducktion" or rType == "Main-Spec" or rType == "Off-Spec" then
+                                                reason = "-DP"
+                                        end
+                                        vf:SetCandidateData(ses, name, "rollInfo", {
+                                                base = tonumber(base),
+                                                SP = tonumber(sp),
+                                                DP = tonumber(dp),
+                                                final = final,
+                                                reason = reason,
+                                        })
                                         vf:Update()
                                 end
                         end


### PR DESCRIPTION
## Summary
- keep full roll info when handling ROLL messages
- include rollInfo in CHAT_MSG_ADDON handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d5fc36e88322932223c855914231