### PR TITLE
Implement Deducktion DP penalty

### DIFF
--- a/ml_core.lua
+++ b/ml_core.lua
@@ -587,6 +587,18 @@ function ScroogeLootML:Award(session, winner, response, reason)
                                         addon:BroadcastPlayerData()
                                 end
                         end
+                        -- Deduct DP when item is awarded for a deducktion response
+                        if response == 3 and PlayerDB then
+                                if PlayerDB[winner] then
+                                        PlayerDB[winner].DP = (PlayerDB[winner].DP or 0) - 50
+                                end
+                                if addon.PlayerData and addon.PlayerData[winner] then
+                                        addon.PlayerData[winner].DP = (addon.PlayerData[winner].DP or 0) - 50
+                                end
+                                if addon.BroadcastPlayerData then
+                                        addon:BroadcastPlayerData()
+                                end
+                        end
                         -- IDEA Switch session ?
 
                         self:AnnounceAward(winner, self.lootTable[session].link, reason and reason.text or db.responses[response].text)


### PR DESCRIPTION
## Summary
- deduct 50 DP when an item is awarded for the `Deducktion` response

## Testing
- `git commit -m "Deduct DP for Deducktion awards"`

------
https://chatgpt.com/codex/tasks/task_e_68890b739c7c8322bbfefbf0b792330c