### PR TITLE
Implement DP floor for Deducktion awards

### DIFF
--- a/ml_core.lua
+++ b/ml_core.lua
@@ -590,10 +590,14 @@ function ScroogeLootML:Award(session, winner, response, reason)
                         -- Deduct DP when item is awarded for a deducktion response
                         if response == 3 and PlayerDB then
                                 if PlayerDB[winner] then
-                                        PlayerDB[winner].DP = (PlayerDB[winner].DP or 0) - 50
+                                        local newDP = (PlayerDB[winner].DP or 0) - 50
+                                        if newDP < -200 then newDP = -200 end
+                                        PlayerDB[winner].DP = newDP
                                 end
                                 if addon.PlayerData and addon.PlayerData[winner] then
-                                        addon.PlayerData[winner].DP = (addon.PlayerData[winner].DP or 0) - 50
+                                        local newDP = (addon.PlayerData[winner].DP or 0) - 50
+                                        if newDP < -200 then newDP = -200 end
+                                        addon.PlayerData[winner].DP = newDP
                                 end
                                 if addon.BroadcastPlayerData then
                                         addon:BroadcastPlayerData()


### PR DESCRIPTION
## Summary
- cap DP penalties from Deducktion awards so a player cannot go below -200 DP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68890c761110832283bea18b1b4a83a0