### PR TITLE
Add Player Management button

### DIFF
--- a/Modules/options.lua
+++ b/Modules/options.lua
@@ -277,16 +277,32 @@ function addon:OptionsTable()
 										type = "toggle",
 										disabled = function() return not self.db.profile.autoLoot end,
 									},
-									autolootBoE = {
-										order = 7,
-										name = L["Autoloot BoE"],
-										desc = L["autoloot_BoE_desc"],
-										type = "toggle",
-										disabled = function() return not self.db.profile.autoLoot end,
-									},
-								},
-							},
-							voteOptions = {
+                                                                       autolootBoE = {
+                                                                               order = 7,
+                                                                               name = L["Autoloot BoE"],
+                                                                               desc = L["autoloot_BoE_desc"],
+                                                                               type = "toggle",
+                                                                               disabled = function() return not self.db.profile.autoLoot end,
+                                                                       },
+                                                                       playerManagement = {
+                                                                               order = 8,
+                                                                               name = L["Player Management"],
+                                                                               type = "execute",
+                                                                               func = function()
+                                                                                       InterfaceOptionsFrame:Hide()
+                                                                                       LibStub("AceConfigDialog-3.0"):CloseAll()
+                                                                                       local pm = addon:GetModule("SLPlayerManagementFrame", true)
+                                                                                       if pm and pm.Show then
+                                                                                               pm:Show()
+                                                                                       else
+                                                                                               local alt = addon:GetModule("SLPlayerManager", true)
+                                                                                               if alt and alt.Show then alt:Show() end
+                                                                                       end
+                                                                               end,
+                                                                       },
+                                                               },
+                                                       },
+                                                       voteOptions = {
 								order = 2,
 								name = L["Voting options"],
 								type = "group",


### PR DESCRIPTION
## Summary
- add a Player Management button below the Looting options in ML settings
- the button opens the Player Management frame

## Testing
- `apt-get update`
- `apt-get install -y lua5.1`
- `find Modules -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: `luac` cannot parse BOM in file)*

------
https://chatgpt.com/codex/tasks/task_e_6889135efccc83229519bbb94f63adcd