### PR TITLE
Add minimap button

### DIFF
--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -355,3 +355,4 @@ L["You cannot use this command without being the Master Looter"] = true
 L["You haven't set a council! You can edit your council by typing '/sl council'"] = true
 L["You're already running a session."] = true
 L["Your note:"] = true
+L["minimap_open_settings"] = "Left-click to open Scrooge Loot settings"

--- a/core.lua
+++ b/core.lua
@@ -268,10 +268,12 @@ function ScroogeLoot:OnInitialize()
 end
 
 function ScroogeLoot:OnEnable()
-	-- Register the player's name
-	self.realmName = GetRealmName()
-	self.playerName = UnitName("player")
-	self:DebugLog(self.playerName, self.version, self.tVersion)
+        -- Register the player's name
+        self.realmName = GetRealmName()
+        self.playerName = UnitName("player")
+        self:DebugLog(self.playerName, self.version, self.tVersion)
+
+        self:CreateMinimapButton()
 
 	-- register events
 	self:RegisterEvent("PARTY_LOOT_METHOD_CHANGED", "OnEvent")
@@ -1641,10 +1643,33 @@ end
 -- @param parent The frame that should hold the button
 -- @return The button object
 function ScroogeLoot:CreateButton(text, parent)
-	local b = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
-	b:SetText(text)
-	b:SetSize(100,25)
-	return b
+        local b = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
+        b:SetText(text)
+        b:SetSize(100,25)
+        return b
+end
+
+--- Creates a minimap button that opens the config frame
+function ScroogeLoot:CreateMinimapButton()
+    if self.minimapButton then return end
+    local b = CreateFrame("Button", "ScroogeLootMinimapButton", Minimap)
+    b:SetSize(32, 32)
+    b:SetFrameStrata("MEDIUM")
+    b:SetFrameLevel(8)
+    b:SetNormalTexture("Interface\\AddOns\\ScroogeLoot\\Utils\\tophat_icon_64x64.tga")
+    b:SetPushedTexture("Interface\\AddOns\\ScroogeLoot\\Utils\\tophat_icon_64x64.tga")
+    b:SetHighlightTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
+    b:SetPoint("TOPLEFT", Minimap, "TOPLEFT")
+    b:SetScript("OnClick", function()
+        LibStub("AceConfigDialog-3.0"):Open("ScroogeLoot")
+    end)
+    b:SetScript("OnEnter", function()
+        self:CreateTooltip("ScroogeLoot", L["minimap_open_settings"])
+    end)
+    b:SetScript("OnLeave", function()
+        self:HideTooltip()
+    end)
+    self.minimapButton = b
 end
 
 --- Displays a tooltip anchored to the mouse


### PR DESCRIPTION
## Summary
- add minimap button using the tophat icon
- open config when clicked
- localize tooltip string

## Testing
- `luac -p core.lua && luac -p Locale/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_68891bcc3cb883229c3f71a363d6da78