### PR TITLE
Add icon metadata

### DIFF
--- a/ScroogeLoot.toc
+++ b/ScroogeLoot.toc
@@ -3,6 +3,7 @@
 ## Notes: Interface for running a Loot Council backported to 3.3.5a
 ## Title: ScroogeLoot
 ## Version: 2.0.4
+## IconTexture: Utils\tophat_icon_64x64.tga
 ## SavedVariables: ScroogeLootDB, ScroogeLootLootDB, PlayerDB
 ## OptionalDeps: LibStub, CallbackHandler-1.0, Ace3, lib-st, LibWindow-1.1, LibDialog-1.0
 


### PR DESCRIPTION
## Summary
- reference tophat icon in addon metadata

## Testing
- `file Utils/tophat_icon_64x64.tga`


------
https://chatgpt.com/codex/tasks/task_e_6889db731a008322b035203f199b4b1f