### PR TITLE
Restore raider DP during attendance checks

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -892,9 +892,13 @@ function SLVotingFrame:GetFrame()
                         local total = data.attended + data.absent
                         data.attendance = total > 0 and math.floor((data.attended / total) * 100) or 0
 
-                        -- Award SP for raiders on attendance check
+                        -- Award SP and restore DP for raiders on attendance check
                         if data.raiderrank then
                                 data.SP = (data.SP or 0) + 5
+                                local currentDP = data.DP or 0
+                                if currentDP < 0 then
+                                        data.DP = math.min(currentDP + 25, 0)
+                                end
                         end
                 end
 


### PR DESCRIPTION
## Summary
- Also restore DP for raiders on attendance check; adds up to +25 DP capped at zero.

## Testing
- `luac -p Modules/votingFrame.lua && echo 'Syntax OK'`
- `luacheck Modules/votingFrame.lua` *(315 warnings / 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fa4cea42483229006b520a049733d