### PR TITLE
Fix DP not awarded on attendance

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -886,20 +886,17 @@ function SLVotingFrame:GetFrame()
                         data.absent = data.absent or 0
                         if inRaid[name] then
                                 data.attended = data.attended + 1
+
+                                -- Award SP and DP for raiders present in the raid
+                                if data.raiderrank then
+                                        data.SP = (data.SP or 0) + 5
+                                        data.DP = math.min((data.DP or 0) + 25, 0)
+                                end
                         else
                                 data.absent = data.absent + 1
                         end
                         local total = data.attended + data.absent
                         data.attendance = total > 0 and math.floor((data.attended / total) * 100) or 0
-
-                        -- Award SP and restore DP for raiders on attendance check
-                        if data.raiderrank then
-                                data.SP = (data.SP or 0) + 5
-                                local currentDP = data.DP or 0
-                                if currentDP < 0 then
-                                        data.DP = math.min(currentDP + 25, 0)
-                                end
-                        end
                 end
 
                 if addon.playerDB and addon.playerDB.global then


### PR DESCRIPTION
## Summary
- Only grant SP and DP to raiders who are present in the raid during attendance checks
- Keep absentees from gaining SP/DP while still tracking absence
- Prevent DP recovery from exceeding zero when awarding attendance

## Testing
- `luac -p Modules/votingFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_68905a6674d08322847feb095e9ef88f