### PR TITLE
Clamp DP within -200 to 0

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -144,12 +144,12 @@ function SLPlayerManagementFrame:Save(target)
     wipe(PlayerDB)
     for _,row in ipairs(t.rows) do
         local d = row.data
-        local pd = {
+            local pd = {
             name = d.name or row.name,
             class = d.class,
             raiderrank = d.raiderrank,
             SP = tonumber(d.SP) or 0,
-            DP = tonumber(d.DP) or 0,
+            DP = math.max(math.min(tonumber(d.DP) or 0, 0), -200),
             attended = tonumber(d.attended) or 0,
             absent = tonumber(d.absent) or 0,
             item1 = d.item1,

--- a/Modules/playerManager.lua
+++ b/Modules/playerManager.lua
@@ -184,7 +184,7 @@ function SLPlayerManager:Save(target)
             class = d.class,
             raiderrank = d.raiderrank,
             SP = tonumber(d.SP) or 0,
-            DP = tonumber(d.DP) or 0,
+            DP = math.max(math.min(tonumber(d.DP) or 0, 0), -200),
             attended = tonumber(d.attended) or 0,
             absent = tonumber(d.absent) or 0,
             item1 = d.item1,
@@ -241,7 +241,8 @@ function SLPlayerManager:ImportData(text)
             d.class = entry:match('class="([^"]*)"') or ""
             d.raiderrank = entry:match('raider="([^"]*)"') == "true"
             d.SP = tonumber(entry:match('SP="([^"]*)"') or 0)
-            d.DP = tonumber(entry:match('DP="([^"]*)"') or 0)
+            local dp = tonumber(entry:match('DP="([^"]*)"') or 0)
+            d.DP = math.max(math.min(dp, 0), -200)
             d.attended = tonumber(entry:match('attended="([^"]*)"') or 0)
             d.absent = tonumber(entry:match('absent="([^"]*)"') or 0)
             d.item1 = entry:match('item1="([^"]*)"')

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -890,7 +890,7 @@ function SLVotingFrame:GetFrame()
                                 -- Award SP and DP for raiders present in the raid
                                 if data.raiderrank then
                                         data.SP = (data.SP or 0) + 5
-                                        data.DP = math.min((data.DP or 0) + 25, 0)
+                                        data.DP = math.max(math.min((data.DP or 0) + 25, 0), -200)
                                 end
                         else
                                 data.absent = data.absent + 1

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -73,6 +73,9 @@ end
 function addon:SetPlayerField(name, field, value)
     if not self.isMasterLooter then return end
     EnsurePlayer(name)
+    if field == "DP" then
+        value = math.max(math.min(tonumber(value) or 0, 0), -200)
+    end
     self.PlayerData[name][field] = value
     self:BroadcastPlayerData()
 end


### PR DESCRIPTION
## Summary
- prevent saving or importing DP outside the -200 to 0 range
- bound raid attendance DP adjustments between -200 and 0
- clamp DP when directly setting player fields

## Testing
- `luac -p Modules/playerManager.lua Modules/playerManagementFrame.lua Modules/votingFrame.lua playerdata.lua`


------
https://chatgpt.com/codex/tasks/task_e_68905d7455a4832293e228658da94a3f