### PR TITLE
Avoid autopass for equippable items

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1128,17 +1128,18 @@ local autopassOverride = {
 }
 
 function ScroogeLoot:AutoPassCheck(subType, equipLoc, link)
-	if not tContains(autopassOverride, equipLoc) then
-		if subType and autopassTable[self.db.global.localizedSubTypes[subType]] then
-			return tContains(autopassTable[self.db.global.localizedSubTypes[subType]], self.playerClass)
-		end
-		-- The item wasn't a type we check for, but it might be a token
-		local id = type(link) == "number" and link or self:GetItemIDFromLink(link) -- Convert to id if needed
-		if SLTokenClasses[id] then -- It's a token
-			return not tContains(SLTokenClasses[id], self.playerClass)
-		end
-	end
-	return false
+        local id = type(link) == "number" and link or self:GetItemIDFromLink(link) -- Convert to id if needed
+        if id and IsEquippableItem(id) and select(1, IsUsableItem(id)) then return false end
+        if not tContains(autopassOverride, equipLoc) then
+                if subType and autopassTable[self.db.global.localizedSubTypes[subType]] then
+                        return tContains(autopassTable[self.db.global.localizedSubTypes[subType]], self.playerClass)
+                end
+                -- The item wasn't a type we check for, but it might be a token
+                if SLTokenClasses[id] then -- It's a token
+                        return not tContains(SLTokenClasses[id], self.playerClass)
+                end
+        end
+        return false
 end
 
 function ScroogeLoot:LocalizeSubTypes()


### PR DESCRIPTION
## Summary
- prevent autopass when the player can equip the item

## Testing
- `luac -p core.lua`

------
https://chatgpt.com/codex/tasks/task_e_68905f6ae78c83228f94d6bd22103618