### PR TITLE
Align voting frame sorting with response priorities

### DIFF
--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -160,11 +160,11 @@ function SLVotingFrame:OnInitialize()
         self.scrollCols = {
                 { name = "Name",       width = 120, DoCellUpdate = self.SetCellName },
                 { name = "Rank",       width = 50,  DoCellUpdate = self.SetCellRank },
-                { name = "Response",   width = 120, DoCellUpdate = self.SetCellResponse },
+                { name = "Response",   width = 120, DoCellUpdate = self.SetCellResponse, comparesort = ResponseSort, sortnext = 7 },
                 { name = "Attendance", width = 70,  DoCellUpdate = self.SetCellAttendance },
                 { name = "Gear 1",     width = 20, DoCellUpdate = self.SetCellGear1 },
                 { name = "Gear 2",     width = 20, DoCellUpdate = self.SetCellGear2 },
-                { name = "Roll",       width = 60,  DoCellUpdate = self.SetCellRoll },
+                { name = "Roll",       width = 60,  DoCellUpdate = self.SetCellRoll, defaultsort = "dsc" },
         }
 	menuFrame = CreateFrame("Frame", "ScroogeLoot_VotingFrame_RightclickMenu", UIParent, "Lib_UIDropDownMenuTemplate")
 	filterMenu = CreateFrame("Frame", "ScroogeLoot_VotingFrame_FilterMenu", UIParent, "Lib_UIDropDownMenuTemplate")
@@ -492,7 +492,7 @@ function SLVotingFrame:SwitchSession(s)
 	for i in ipairs(self.frame.st.cols) do
 		self.frame.st.cols[i].sort = nil
 	end
-	self.frame.st.cols[4].sort = "asc"
+        self.frame.st.cols[3].sort = "asc"
 	FauxScrollFrame_OnVerticalScroll(self.frame.st.scrollframe, 0, self.frame.st.rowHeight, function() self.frame.st:Refresh() end) -- Reset scrolling to 0
 	self:Update()
 	self:UpdatePeopleToVote()

--- a/core.lua
+++ b/core.lua
@@ -83,11 +83,11 @@ function ScroogeLoot:OnInitialize()
 		AUTOPASS			= { color = {0.7,0.7,0.7,1},		sort = 801,		text = L["Autopass"], },
 		DISABLED			= { color = {0.3, 0.35, 0.5},		sort = 802,		text = L["Candidate has disabled ScroogeLoot"], },
 		--[[1]]			  { color = {0,1,0,1},				sort = 1,		text = "Scrooge",},
-		--[[2]]			  { color = {1,0.5,0,1},			sort = 2,		text = "Drool",	},
-		--[[3]]			  { color = {0,0.7,0.7,1},			sort = 3,		text = "Deducktion",},
-                --[[4]]                   { color = {1,1,0,1},               sort = 4,                text = "Main-Spec",},
-                --[[5]]                   { color = {0.9,0.6,1,1},             sort = 5,                text = "Off-Spec",},
-                --[[6]]                   { color = {0.7,0.7,0.7,1},           sort = 6,                text = "Transmog",},
+		--[[2]]			  { color = {1,0.5,0,1},			sort = 1,		text = "Drool",	},
+		--[[3]]			  { color = {0,0.7,0.7,1},			sort = 2,		text = "Deducktion",},
+                --[[4]]                   { color = {1,1,0,1},               sort = 3,                text = "Main-Spec",},
+                --[[5]]                   { color = {0.9,0.6,1,1},             sort = 4,                text = "Off-Spec",},
+                --[[6]]                   { color = {0.7,0.7,0.7,1},           sort = 5,                text = "Transmog",},
 	}
 	self.roleTable = {
 		TANK =		L["Tank"],


### PR DESCRIPTION
## Summary
- treat buttons 1 and 2 as equal priority for candidate responses
- sort the voting frame by response weight with roll value as the final tie-breaker

## Testing
- `luac -p core.lua Modules/votingFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_689063de61fc8322b44c1d47ad20bed5