### PR TITLE
Ensure only master looter PlayerDB is used

### DIFF
--- a/Modules/lootFrame.lua
+++ b/Modules/lootFrame.lua
@@ -34,7 +34,7 @@ local function CanEquipItem(name, item) return true end
 -- Returns true if the current player has Raider rank
 local function PlayerHasRaiderRank()
     local player = UnitName("player")
-    local data = (PlayerDB and PlayerDB[player]) or (addon.PlayerData and addon.PlayerData[player])
+    local data = (addon.PlayerData and addon.PlayerData[player]) or (PlayerDB and PlayerDB[player])
     return data and data.raiderrank
 end
 
@@ -43,7 +43,7 @@ end
 local function PlayerHasReservedItem(itemName)
     if not itemName or itemName == "" then return false end
     local player = UnitName("player")
-    local data = (PlayerDB and PlayerDB[player]) or (addon.PlayerData and addon.PlayerData[player])
+    local data = (addon.PlayerData and addon.PlayerData[player]) or (PlayerDB and PlayerDB[player])
     if not data then return false end
 
     local function normalize(entry)
@@ -61,13 +61,13 @@ local function PlayerHasReservedItem(itemName)
 end
 
 local function OnRollOptionClick(playerName, rollType, sessionID)
-    local db = PlayerDB and PlayerDB[playerName]
+    local db = (addon.PlayerData and addon.PlayerData[playerName]) or (PlayerDB and PlayerDB[playerName])
     if not db then
         local _, class = UnitClass(playerName)
         if RegisterPlayer then
             RegisterPlayer(playerName, class)
         end
-        db = PlayerDB and PlayerDB[playerName]
+        db = (addon.PlayerData and addon.PlayerData[playerName]) or (PlayerDB and PlayerDB[playerName])
     end
     if not db then
         print("Player not found in PlayerDB:", playerName)

--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -82,8 +82,9 @@ end
 function SLPlayerManagementFrame:LoadData(target)
     local t = target or self.frame.content
     t.rows = {}
-    if not PlayerDB then return end
-    for name, data in pairs(PlayerDB) do
+    local source = addon.PlayerData or PlayerDB
+    if not source then return end
+    for name, data in pairs(source) do
         local copy = {}
         for k,v in pairs(data) do copy[k] = v end
         copy.name = name

--- a/core.lua
+++ b/core.lua
@@ -789,19 +789,20 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 				self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
 
 			elseif command == "playerData" then
-				-- Update local PlayerData from the master looter
-                                if not self.isMasterLooter then
-                                        local incomingData = unpack(data)
-                                        self.PlayerData = incomingData
-                                        if self.EnsureNameFields then
-                                                self:EnsureNameFields()
-                                        end
-                                        if self.playerDB and self.playerDB.global then
-                                                self.playerDB.global.playerData = incomingData
-                                        end
-                                end
-			elseif command == "message" then
-				self:Print(unpack(data))
+-- Update local PlayerData from the master looter
+if not self.isMasterLooter and self:UnitIsUnit(sender, self.masterLooter) then
+local incomingData = unpack(data)
+self.PlayerData = incomingData
+if self.EnsureNameFields then
+self:EnsureNameFields()
+end
+if self.playerDB and self.playerDB.global then
+self.playerDB.global.playerData = incomingData
+end
+PlayerDB = incomingData
+end
+elseif command == "message" then
+self:Print(unpack(data))
 
 			elseif command == "session_end" and self.enabled then
 				if self:UnitIsUnit(sender, self.masterLooter) then
@@ -1812,7 +1813,7 @@ function ScroogeLoot:ShowCandidates(candidateList)
 
     local rows = {}
     for _, playerName in ipairs(candidateList) do
-        local p = PlayerDB and PlayerDB[playerName]
+        local p = (self.PlayerData and self.PlayerData[playerName]) or (PlayerDB and PlayerDB[playerName])
         if p then
             table.insert(rows, {
                 name = playerName,

--- a/ml_core.lua
+++ b/ml_core.lua
@@ -94,19 +94,19 @@ end
 
 function ScroogeLootML:AddCandidate(name, class, role, rank, enchant, lvl)
         addon:DebugLog("ML:AddCandidate", name, class, role, rank, enchant, lvl)
-        local pd = nil
-        if PlayerDB and PlayerDB[name] then
-                pd = PlayerDB[name]
-        elseif addon.PlayerData and addon.PlayerData[name] then
-                pd = addon.PlayerData[name]
-        end
-        if not pd then
-                local _, cls = UnitClass(name)
-                if RegisterPlayer then
-                        RegisterPlayer(name, cls)
-                end
-                pd = PlayerDB and PlayerDB[name] or {}
-        end
+local pd = nil
+if addon.PlayerData and addon.PlayerData[name] then
+pd = addon.PlayerData[name]
+elseif PlayerDB and PlayerDB[name] then
+pd = PlayerDB[name]
+end
+if not pd then
+local _, cls = UnitClass(name)
+if RegisterPlayer then
+RegisterPlayer(name, cls)
+end
+pd = (addon.PlayerData and addon.PlayerData[name]) or (PlayerDB and PlayerDB[name]) or {}
+end
         self.candidates[name] = {
                 ["class"]       = class,
                 ["role"]        = role or "DAMAGER",


### PR DESCRIPTION
## Summary
- accept PlayerDB updates only from the raid's master looter
- use the master looter's PlayerDB for raid-related UI and logic

## Testing
- `luac -p core.lua Modules/lootFrame.lua Modules/votingFrame.lua Modules/playerManagementFrame.lua ml_core.lua`


------
https://chatgpt.com/codex/tasks/task_e_689078306dc08322b3380f6b7da8ebb8