### PR TITLE
Use master looter PlayerDB in raids

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -788,11 +788,12 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
 			elseif command == "playerInfoRequest" then
 				self:SendCommand(sender, "playerInfo", self:GetPlayerInfo())
 
-			elseif command == "playerData" then
-				-- Update local PlayerData from the master looter
+                        elseif command == "playerData" then
+                                -- Update local PlayerData from the master looter
                                 if not self.isMasterLooter then
                                         local incomingData = unpack(data)
                                         self.PlayerData = incomingData
+                                        PlayerDB = incomingData
                                         if self.EnsureNameFields then
                                                 self:EnsureNameFields()
                                         end

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -167,6 +167,7 @@ local function UpdateAttendance(playerName)
 end
 
 function RegisterPlayer(name, class)
+    if not addon.isMasterLooter then return end
     InitializePlayerData(name, class)
     UpdateAttendance(name)
 end


### PR DESCRIPTION
## Summary
- Replace local PlayerDB with master looter's broadcast to ensure consistency
- Prevent non-master players from registering or altering PlayerDB entries

## Testing
- `sudo apt-get install -y lua5.1`
- `luac -p core.lua playerdata.lua`


------
https://chatgpt.com/codex/tasks/task_e_68908d53d8448322a8ad261ca52a004a