### PR TITLE
Use PlayerData when iterating players

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -82,8 +82,8 @@ end
 function SLPlayerManagementFrame:LoadData(target)
     local t = target or self.frame.content
     t.rows = {}
-    if not PlayerDB then return end
-    for name, data in pairs(PlayerDB) do
+    if not addon.PlayerData then return end
+    for name, data in pairs(addon.PlayerData) do
         local copy = {}
         for k,v in pairs(data) do copy[k] = v end
         copy.name = name

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -856,7 +856,8 @@ function SLVotingFrame:GetFrame()
                 if not addon.isMasterLooter then
                         return addon:Print(L["You cannot use this command without being the Master Looter"])
                 end
-                PlayerDB = PlayerDB or {}
+                addon.PlayerData = addon.PlayerData or {}
+                local playerDB = addon.PlayerData
                 local inRaid = {}
 
                 if addon:IsInRaid() then
@@ -881,7 +882,7 @@ function SLVotingFrame:GetFrame()
                         end
                 end
 
-                for name, data in pairs(PlayerDB) do
+                for name, data in pairs(playerDB) do
                         data.attended = data.attended or 0
                         data.absent = data.absent or 0
                         if inRaid[name] then
@@ -900,8 +901,10 @@ function SLVotingFrame:GetFrame()
                 end
 
                 if addon.playerDB and addon.playerDB.global then
-                        addon.playerDB.global.playerData = PlayerDB
+                        addon.playerDB.global.playerData = playerDB
                 end
+
+                PlayerDB = playerDB
 
                 if SLVotingFrame.frame and SLVotingFrame.frame.st and SLVotingFrame.frame.st.data then
                         for _, row in ipairs(SLVotingFrame.frame.st.data) do


### PR DESCRIPTION
## Summary
- avoid treating AceDB metadata as player entries by iterating over `ScroogeLoot.PlayerData`
- update attendance check to read/write `PlayerData`

## Testing
- `luacheck Modules/playerManagementFrame.lua Modules/votingFrame.lua`

------
https://chatgpt.com/codex/tasks/task_e_6890c971b09083229a2b6ff287ff46ba