### PR TITLE
Persist PlayerDB across sessions

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -166,11 +166,12 @@ function SLPlayerManagementFrame:Save(target)
             pd.attendance = 100
         end
         local name = pd.name
-        PlayerDB[name] = pd
-        row.name = name
-    end
-    addon.PlayerData = PlayerDB
-    addon:Print(L["Player Management"]..": "..L["Save"].."!")
+PlayerDB[name] = pd
+row.name = name
+end
+PlayerDB = addon:SanitizePlayerDB(PlayerDB)
+addon.PlayerData = PlayerDB
+addon:Print(L["Player Management"]..": "..L["Save"].."!")
 end
 
 return SLPlayerManagementFrame

--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -170,9 +170,6 @@ function SLPlayerManagementFrame:Save(target)
         row.name = name
     end
     addon.PlayerData = PlayerDB
-    if addon.playerDB and addon.playerDB.global then
-        addon.playerDB.global.playerData = PlayerDB
-    end
     addon:Print(L["Player Management"]..": "..L["Save"].."!")
 end
 

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -900,11 +900,7 @@ function SLVotingFrame:GetFrame()
                         data.attendance = total > 0 and math.floor((data.attended / total) * 100) or 0
                 end
 
-                if addon.playerDB and addon.playerDB.global then
-                        addon.playerDB.global.playerData = playerDB
-                end
-
-                PlayerDB = playerDB
+               PlayerDB = playerDB
 
                 if SLVotingFrame.frame and SLVotingFrame.frame.st and SLVotingFrame.frame.st.data then
                         for _, row in ipairs(SLVotingFrame.frame.st.data) do

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -900,7 +900,7 @@ function SLVotingFrame:GetFrame()
                         data.attendance = total > 0 and math.floor((data.attended / total) * 100) or 0
                 end
 
-               PlayerDB = playerDB
+PlayerDB = addon:SanitizePlayerDB(playerDB)
 
                 if SLVotingFrame.frame and SLVotingFrame.frame.st and SLVotingFrame.frame.st.data then
                         for _, row in ipairs(SLVotingFrame.frame.st.data) do

--- a/core.lua
+++ b/core.lua
@@ -49,6 +49,19 @@ local frames = {} -- Contains all frames created by ScroogeLoot:CreateFrame()
 local unregisterGuildEvent = false
 local player_relogged = true -- Determines if we potentially need data from the ML due to /rl
 
+function ScroogeLoot:SanitizePlayerDB(db)
+       db = db or {}
+       if type(db.global) == "table" then
+               for name, data in pairs(db.global) do
+                       db[name] = data
+               end
+               db.global = nil
+       end
+       db.profileKeys = nil
+       db.profiles = nil
+       return db
+end
+
 function ScroogeLoot:OnInitialize()
 	--IDEA Consider if we want everything on self, or just whatever modules could need.
   	self.version = "2.0.4" -- hard code the version so reload ui updates will report correct version
@@ -238,7 +251,7 @@ function ScroogeLoot:OnInitialize()
        self.db = LibStub("AceDB-3.0"):New("ScroogeLootDB", self.defaults, true)
        self.lootDB = LibStub("AceDB-3.0"):New("ScroogeLootLootDB")
        -- PlayerDB persists data between sessions via SavedVariables
-       PlayerDB = PlayerDB or {}
+       PlayerDB = self:SanitizePlayerDB(PlayerDB)
        --[[ Format:
 	"playerName" = {
 		[#] = {"lootWon", "date (d/m/y)", "time (h:m:s)", "instance", "boss", "votes", "itemReplaced1", "itemReplaced2", "response", "responseID", "color", "class", "isAwardReason"}
@@ -792,7 +805,7 @@ function ScroogeLoot:OnCommReceived(prefix, serializedMsg, distri, sender)
                         elseif command == "playerData" then
                                 -- Update local PlayerData from the master looter
                                 if not self.isMasterLooter then
-                                       local incomingData = unpack(data)
+                                       local incomingData = self:SanitizePlayerDB(unpack(data))
                                        self.PlayerData = incomingData
                                        PlayerDB = incomingData
                                        ScroogeLoot.PlayerData = self.PlayerData

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -112,7 +112,7 @@ end
 
 -- Simple player registration and attendance update
 local addonName = ...
-PlayerDB = PlayerDB or {}
+PlayerDB = addon:SanitizePlayerDB(PlayerDB)
 
 local function InitializePlayerData(playerName, class)
     if not PlayerDB[playerName] then

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -104,9 +104,6 @@ end
 
 -- Broadcast the complete PlayerData table to the raid.
 function addon:BroadcastPlayerData()
-    if self.playerDB and self.playerDB.global then
-        self.playerDB.global.playerData = self.PlayerData
-    end
     if not self.isMasterLooter then return end
     -- Send to everyone in the current group/raid
     self:SendCommand("group", "playerData", self.PlayerData)


### PR DESCRIPTION
## Summary
- Use SavedVariables table for PlayerDB instead of AceDB so data persists between logins
- Update management and voting modules to store and broadcast PlayerDB directly

## Testing
- `find . -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: unexpected symbol near '')*
- `find . -name '*.lua' ! -path './Utils/tokenData.lua' ! -path './Modules/options.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_6890f81a0cfc832298b48abe99e46789