### PR TITLE
Fix repeated save in player management

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -140,11 +140,20 @@ end
 
 function SLPlayerManagementFrame:Save(target)
     local t = target or self.frame.content
-    PlayerDB = PlayerDB or {}
-    wipe(PlayerDB)
-    for _,row in ipairs(t.rows) do
+    -- Determine the target database table and ensure it exists
+    local db
+    if addon.playerDB and addon.playerDB.global then
+        addon.playerDB.global.playerData = addon.playerDB.global.playerData or {}
+        db = addon.playerDB.global.playerData
+    else
+        PlayerDB = PlayerDB or {}
+        db = PlayerDB
+    end
+
+    wipe(db)
+    for _, row in ipairs(t.rows) do
         local d = row.data
-            local pd = {
+        local pd = {
             name = d.name or row.name,
             class = d.class,
             raiderrank = d.raiderrank,
@@ -166,13 +175,12 @@ function SLPlayerManagementFrame:Save(target)
             pd.attendance = 100
         end
         local name = pd.name
-        PlayerDB[name] = pd
+        db[name] = pd
         row.name = name
     end
-    addon.PlayerData = PlayerDB
-    if addon.playerDB and addon.playerDB.global then
-        addon.playerDB.global.playerData = PlayerDB
-    end
+
+    addon.PlayerData = db
+    PlayerDB = db
     addon:Print(L["Player Management"]..": "..L["Save"].."!")
 end
 


### PR DESCRIPTION
## Summary
- ensure Player Management saves update the correct player database table each time

## Testing
- `luac -p Modules/playerManagementFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_689224b2383883229b1fba7f3ba28c9b