### PR TITLE
Fix PlayerDB persistence

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -170,9 +170,7 @@ function SLPlayerManagementFrame:Save(target)
         row.name = name
     end
     addon.PlayerData = PlayerDB
-    if addon.playerDB and addon.playerDB.global then
-        addon.playerDB.global.playerData = PlayerDB
-    end
+    addon:BroadcastPlayerData()
     addon:Print(L["Player Management"]..": "..L["Save"].."!")
 end
 

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -900,11 +900,7 @@ function SLVotingFrame:GetFrame()
                         data.attendance = total > 0 and math.floor((data.attended / total) * 100) or 0
                 end
 
-                if addon.playerDB and addon.playerDB.global then
-                        addon.playerDB.global.playerData = playerDB
-                end
-
-                PlayerDB = playerDB
+                addon:BroadcastPlayerData()
 
                 if SLVotingFrame.frame and SLVotingFrame.frame.st and SLVotingFrame.frame.st.data then
                         for _, row in ipairs(SLVotingFrame.frame.st.data) do

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -115,7 +115,12 @@ end
 
 -- Simple player registration and attendance update
 local addonName = ...
-PlayerDB = PlayerDB or {}
+
+-- Ensure the global PlayerDB table points to the addon's persisted data
+PlayerDB = addon.PlayerData
+if addon.playerDB and addon.playerDB.global then
+    addon.playerDB.global.playerData = PlayerDB
+end
 
 local function InitializePlayerData(playerName, class)
     if not PlayerDB[playerName] then

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -106,6 +106,7 @@ end
 function addon:BroadcastPlayerData()
     if self.playerDB and self.playerDB.global then
         self.playerDB.global.playerData = self.PlayerData
+        PlayerDB = self.PlayerData
     end
     if not self.isMasterLooter then return end
     -- Send to everyone in the current group/raid


### PR DESCRIPTION
## Summary
- ensure PlayerDB references the addon's AceDB-stored PlayerData

## Testing
- `luac -p playerdata.lua`


------
https://chatgpt.com/codex/tasks/task_e_689237c794ec8322be90f87b3235ae22