### PR TITLE
Centralize player info in saved PlayerDB

### DIFF
--- a/Modules/playerManagementFrame.lua
+++ b/Modules/playerManagementFrame.lua
@@ -82,8 +82,8 @@ end
 function SLPlayerManagementFrame:LoadData(target)
     local t = target or self.frame.content
     t.rows = {}
-    if not addon.PlayerData then return end
-    for name, data in pairs(addon.PlayerData) do
+    if not PlayerDB then return end
+    for name, data in pairs(PlayerDB) do
         local copy = {}
         for k,v in pairs(data) do copy[k] = v end
         copy.name = name

--- a/Modules/votingFrame.lua
+++ b/Modules/votingFrame.lua
@@ -856,8 +856,8 @@ function SLVotingFrame:GetFrame()
                 if not addon.isMasterLooter then
                         return addon:Print(L["You cannot use this command without being the Master Looter"])
                 end
-                addon.PlayerData = addon.PlayerData or {}
-                local playerDB = addon.PlayerData
+                PlayerDB = PlayerDB or {}
+                local playerDB = PlayerDB
                 local inRaid = {}
 
                 if addon:IsInRaid() then

--- a/playerdata.lua
+++ b/playerdata.lua
@@ -2,8 +2,9 @@
 -- Only the master looter may modify the table.
 
 local addon = LibStub("AceAddon-3.0"):GetAddon("ScroogeLoot")
-
-addon.PlayerData = addon.PlayerData or {}
+-- Use the saved variables table as the single source of truth for player info
+PlayerDB = PlayerDB or {}
+addon.PlayerData = PlayerDB
 
 -- Creates entry for player if not present
 local function EnsurePlayer(name)
@@ -115,7 +116,6 @@ end
 
 -- Simple player registration and attendance update
 local addonName = ...
-PlayerDB = PlayerDB or {}
 
 local function InitializePlayerData(playerName, class)
     if not PlayerDB[playerName] then


### PR DESCRIPTION
## Summary
- Store player data directly in the saved `PlayerDB` table and expose it via `addon.PlayerData`
- Load player info for the Player Management frame from `PlayerDB`
- Reference `PlayerDB` when performing Attendance Check in the Voting frame

## Testing
- `luac -p playerdata.lua Modules/playerManagementFrame.lua Modules/votingFrame.lua`


------
https://chatgpt.com/codex/tasks/task_e_689b0b8950ac8322a39db11b642954c7